### PR TITLE
fix(ui): cue-kleur via dropdown + zichtbare balk in cuelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 Alle noemenswaardige wijzigingen aan dit project. Format volgens
 [Keep a Changelog](https://keepachangelog.com/nl/1.1.0/).
 
+## [Unreleased]
+
+### Gewijzigd
+- Inspector-kleurveld is nu een dropdown met preset cue-kleuren (QLab-stijl)
+  inclusief kleur-swatches. Niet-preset hex-waarden uit oudere workspaces
+  blijven bewaard als "Aangepast".
+- Cue-kleur is in de cuelist nu zichtbaar als gekleurde balk op de
+  nummer-kolom plus subtiele row-tint, in plaats van alleen een (nauwelijks
+  zichtbare) tekstkleur op het nummer.
+
 ## [0.3.0] — 2026-04-23
 
 ### Gewijzigd

--- a/livefire/ui/cuelist.py
+++ b/livefire/ui/cuelist.py
@@ -7,14 +7,30 @@ from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtGui import QBrush, QColor
 from PyQt6.QtWidgets import (
     QTreeWidget, QTreeWidgetItem, QHeaderView, QAbstractItemView,
+    QStyledItemDelegate, QStyle,
 )
 
 from ..cues import Cue, CueType, ContinueMode
 from ..workspace import Workspace
-from .style import STATE_COLORS, ACCENT, TEXT_DIM
+from .style import STATE_COLORS, ACCENT, TEXT_DIM, tint_for_row
 
 
 COLUMNS = ["Nr", "Type", "Naam", "Duur", "Continue", "Status"]
+
+
+class _CueRowDelegate(QStyledItemDelegate):
+    """Schildert zelf de per-cel BackgroundRole-brush. Nodig omdat Qt's
+    stylesheet voor ``QTreeWidget::item`` (padding/border) normaal
+    ``QTreeWidgetItem.setBackground()`` negeert."""
+
+    def paint(self, painter, option, index):
+        bg = index.data(Qt.ItemDataRole.BackgroundRole)
+        if isinstance(bg, QBrush) and bg.color().alpha() > 0:
+            if not (option.state & QStyle.StateFlag.State_Selected):
+                painter.save()
+                painter.fillRect(option.rect, bg)
+                painter.restore()
+        super().paint(painter, option, index)
 
 
 def _fmt_duration(sec: float) -> str:
@@ -56,6 +72,8 @@ class CueListWidget(QTreeWidget):
         self.setColumnWidth(4, 120)
         self.setColumnWidth(5, 80)
 
+        self.setItemDelegate(_CueRowDelegate(self))
+
         self.itemSelectionChanged.connect(self._on_selection)
         self.itemDoubleClicked.connect(self._on_double_click)
 
@@ -92,12 +110,14 @@ class CueListWidget(QTreeWidget):
         # Kleur status-cel
         color = STATE_COLORS.get(cue.state, QColor("#888"))
         item.setForeground(5, QBrush(color))
-        # Cue-color tag op nummer-cel
+        # Cue-color tag: volle kleur als balk op nummer-kolom, lichte tint over
+        # de rest zodat de regel direct als gekleurde cue herkenbaar is.
         if cue.color:
-            try:
-                item.setForeground(0, QBrush(QColor(cue.color)))
-            except Exception:
-                pass
+            full = QBrush(QColor(cue.color))
+            tint = QBrush(tint_for_row(cue.color))
+            item.setBackground(0, full)
+            for col in range(1, len(COLUMNS)):
+                item.setBackground(col, tint)
         return item
 
     def update_cue(self, cue_id: str) -> None:

--- a/livefire/ui/inspector.py
+++ b/livefire/ui/inspector.py
@@ -4,8 +4,8 @@ niet samengedrukt worden (zelfde les als v0.2)."""
 
 from __future__ import annotations
 
-from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtGui import QFont
+from PyQt6.QtCore import Qt, pyqtSignal, QSize
+from PyQt6.QtGui import QFont, QColor, QIcon, QPixmap
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QFormLayout, QLineEdit, QDoubleSpinBox, QSpinBox,
     QComboBox, QPlainTextEdit, QGroupBox, QScrollArea, QPushButton, QFileDialog,
@@ -14,6 +14,17 @@ from PyQt6.QtWidgets import (
 
 from ..cues import Cue, CueType, ContinueMode
 from ..workspace import Workspace
+from .style import CUE_COLORS
+
+
+def _swatch_icon(hex_color: str, size: int = 14) -> QIcon:
+    """Maak een vierkant kleur-swatch als QIcon voor de dropdown."""
+    pm = QPixmap(size, size)
+    if hex_color:
+        pm.fill(QColor(hex_color))
+    else:
+        pm.fill(QColor(0, 0, 0, 0))  # transparant voor "Geen"
+    return QIcon(pm)
 
 
 class InspectorWidget(QWidget):
@@ -56,12 +67,14 @@ class InspectorWidget(QWidget):
         self.ed_name = QLineEdit()
         self.cb_type = QComboBox()
         self.cb_type.addItems(CueType.ALL)
-        self.ed_color = QLineEdit()
-        self.ed_color.setPlaceholderText("#3aa2e6 of leeg")
+        self.cb_color = QComboBox()
+        self.cb_color.setIconSize(QSize(14, 14))
+        for label, hex_color in CUE_COLORS:
+            self.cb_color.addItem(_swatch_icon(hex_color), label, hex_color)
         form.addRow("Nummer", self.ed_number)
         form.addRow("Type", self.cb_type)
         form.addRow("Naam", self.ed_name)
-        form.addRow("Kleur", self.ed_color)
+        form.addRow("Kleur", self.cb_color)
         lay.addWidget(grp_basic)
 
         # ---- Timing --------------------------------------------------------
@@ -132,8 +145,7 @@ class InspectorWidget(QWidget):
         lay.addStretch(1)
 
         # ---- wire changes --------------------------------------------------
-        for w in (self.ed_number, self.ed_name, self.ed_color, self.ed_path,
-                  self.ed_notes):
+        for w in (self.ed_number, self.ed_name, self.ed_path, self.ed_notes):
             if isinstance(w, QPlainTextEdit):
                 w.textChanged.connect(self._on_any_change)
             else:
@@ -145,6 +157,7 @@ class InspectorWidget(QWidget):
         self.cb_type.currentTextChanged.connect(self._on_type_change)
         self.cb_continue.currentIndexChanged.connect(self._on_any_change)
         self.cb_target.currentIndexChanged.connect(self._on_any_change)
+        self.cb_color.currentIndexChanged.connect(self._on_any_change)
         self.chk_fade_stops.toggled.connect(self._on_any_change)
 
         self.set_cue(None)
@@ -203,7 +216,7 @@ class InspectorWidget(QWidget):
         self.ed_number.setText(cue.cue_number)
         self.ed_name.setText(cue.name)
         self.cb_type.setCurrentText(cue.cue_type)
-        self.ed_color.setText(cue.color)
+        self._select_color(cue.color)
 
         self.sp_pre.setValue(cue.pre_wait)
         self.sp_dur.setValue(cue.duration)
@@ -248,7 +261,7 @@ class InspectorWidget(QWidget):
         c.cue_number = self.ed_number.text()
         c.name = self.ed_name.text()
         c.cue_type = self.cb_type.currentText()
-        c.color = self.ed_color.text().strip()
+        c.color = self.cb_color.currentData() or ""
         c.pre_wait = self.sp_pre.value()
         c.duration = self.sp_dur.value()
         c.post_wait = self.sp_post.value()
@@ -265,6 +278,21 @@ class InspectorWidget(QWidget):
         c.notes = self.ed_notes.toPlainText()
         self.workspace.dirty = True
         self.cue_changed.emit(c)
+
+    def _select_color(self, hex_color: str) -> None:
+        """Selecteer de juiste preset in cb_color. Als hex_color geen preset is
+        (bv. geërfd uit oudere workspace), voeg hem tijdelijk toe als 'Aangepast'."""
+        idx = self.cb_color.findData(hex_color)
+        if idx < 0 and hex_color:
+            self.cb_color.addItem(
+                _swatch_icon(hex_color),
+                f"Aangepast ({hex_color})",
+                hex_color,
+            )
+            idx = self.cb_color.count() - 1
+        if idx < 0:
+            idx = 0  # "Geen"
+        self.cb_color.setCurrentIndex(idx)
 
     def _browse_file(self) -> None:
         path, _ = QFileDialog.getOpenFileName(

--- a/livefire/ui/style.py
+++ b/livefire/ui/style.py
@@ -26,6 +26,30 @@ STATE_COLORS = {
 }
 
 
+# QLab-geïnspireerde cue-kleuren, afgestemd op ons donkere thema.
+# (label, hex). Volgorde bepaalt de dropdown in de inspector.
+CUE_COLORS: list[tuple[str, str]] = [
+    ("Geen",    ""),
+    ("Rood",    "#c0392b"),
+    ("Oranje",  "#d35400"),
+    ("Geel",    "#c9a227"),
+    ("Groen",   "#2e8b57"),
+    ("Cyaan",   "#2aa198"),
+    ("Blauw",   "#2980b9"),
+    ("Paars",   "#7d3c98"),
+    ("Roze",    "#c71585"),
+    ("Grijs",   "#606060"),
+]
+
+
+def tint_for_row(hex_color: str, alpha: int = 110) -> QColor:
+    """Geef een semi-transparante variant van hex_color terug voor row-backgrounds.
+    Donker thema: alpha ~110/255 geeft duidelijk zichtbaar maar niet schreeuwend."""
+    c = QColor(hex_color)
+    c.setAlpha(alpha)
+    return c
+
+
 STYLESHEET = f"""
 QMainWindow, QWidget {{
     background-color: {BG_DARK};


### PR DESCRIPTION
## Summary
- Inspector: kleur-veld is een `QComboBox` met preset cue-kleuren (QLab-stijl) + swatches, i.p.v. een vrije hex-tekstinvoer die onzichtbaar resultaat gaf.
- Cuelist: volle kleur als balk op de nummer-kolom, halftransparante tint over de rest, geschilderd via custom `QStyledItemDelegate` (Qt's stylesheet negeert normaal `setBackground` op items).
- Niet-preset hex uit oudere workspaces blijft bewaard als 'Aangepast'.

## Test plan
- [x] pytest groen (6/6)
- [x] Visueel: dropdown toont swatches, gekleurde balk + tint zichtbaar in cuelist
- [x] Geen kleur = geen tint

🤖 Generated with [Claude Code](https://claude.com/claude-code)