### PR TITLE
feat(audio): per-cue fade-in en fade-out + crossfades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/
 *.livefire
 !tests/**/*.livefire
 settings.json
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Alle noemenswaardige wijzigingen aan dit project. Format volgens
 ## [Unreleased]
 
 ### Toegevoegd
+- Per-cue **Fade-in** en **Fade-out** (s) op Audio-cues in de inspector.
+  Overlappende audio-cues geven hiermee een natuurlijke crossfade: bij
+  AUTO_FOLLOW start de volgende cue zodra de main-playback van de huidige
+  cue eindigt, terwijl de fade-out parallel doorloopt. Fields worden
+  meegenomen in de workspace-roundtrip.
 - Voorkeuren-dialog (Bestand → Voorkeuren…, Ctrl+,) met output-device- en
   samplerate-keuze. Selectie wordt via QSettings persistent opgeslagen op
   basis van device-naam (niet index), zodat USB-herconnects geen invloed

--- a/livefire/cues/base.py
+++ b/livefire/cues/base.py
@@ -68,6 +68,8 @@ class Cue:
     loops: int = 1             # 1 = 1x, 0 = oneindig, N = N keer
     audio_start_offset: float = 0.0
     audio_end_offset: float = 0.0
+    audio_fade_in: float = 0.0   # s, 0 = hard in
+    audio_fade_out: float = 0.0  # s, 0 = hard out
 
     # Fade-target
     target_cue_id: str = ""    # voor Stop, Fade, Start

--- a/livefire/engines/audio.py
+++ b/livefire/engines/audio.py
@@ -82,6 +82,7 @@ class AudioSource:
         loops: int = 1,
         start_offset_s: float = 0.0,
         end_offset_s: float = 0.0,
+        fade_in_s: float = 0.0,
     ):
         self.cue_id = cue_id
         self._samples = samples
@@ -101,12 +102,19 @@ class AudioSource:
         self._loops_total = loops
         self._loops_done = 0
 
-        # Gain
-        g = db_to_linear(volume_db)
-        self._current_gain = g
-        self._target_gain = g
-        self._ramp_frames = 0
-        self._ramp_delta = 0.0
+        # Gain: bij fade-in starten we op stilte en rampen we naar volume_db.
+        final_g = db_to_linear(volume_db)
+        fade_in_frames = max(0, int(fade_in_s * sample_rate))
+        if fade_in_frames > 0:
+            self._current_gain = 0.0
+            self._target_gain = final_g
+            self._ramp_frames = fade_in_frames
+            self._ramp_delta = final_g / fade_in_frames
+        else:
+            self._current_gain = final_g
+            self._target_gain = final_g
+            self._ramp_frames = 0
+            self._ramp_delta = 0.0
         self._stop_at_end_of_ramp = False
 
         self._finished = False
@@ -313,6 +321,7 @@ class AudioEngine:
         loops: int = 1,
         start_offset: float = 0.0,
         end_offset: float = 0.0,
+        fade_in: float = 0.0,
     ) -> bool:
         """Laadt het bestand, resamplet indien nodig, registreert de source."""
         if not self.available:
@@ -345,6 +354,7 @@ class AudioEngine:
             loops=loops,
             start_offset_s=start_offset,
             end_offset_s=end_offset,
+            fade_in_s=fade_in,
         )
         with self._lock:
             # Als deze cue al speelt, eerst oude source weg
@@ -364,7 +374,16 @@ class AudioEngine:
         src.apply_fade(target_db, duration_s, stops=stops)
         return True
 
-    def stop_cue(self, cue_id: str) -> None:
+    def stop_cue(self, cue_id: str, fade_out: float = 0.0) -> None:
+        """Stop een cue. Met fade_out > 0: fade naar stilte en stop dan; de
+        source blijft tijdens de fade in de mixer zodat overlap met een
+        nieuwe cue een natuurlijke crossfade geeft."""
+        if fade_out > 0:
+            with self._lock:
+                src = self._sources.get(cue_id)
+            if src is not None:
+                src.apply_fade(-120.0, fade_out, stops=True)
+            return
         with self._lock:
             src = self._sources.pop(cue_id, None)
         if src is not None:

--- a/livefire/playback/controller.py
+++ b/livefire/playback/controller.py
@@ -28,6 +28,7 @@ class _Running:
     phase: str = "pre_wait"   # pre_wait | action | post_wait | done
     phase_started_at: float = 0.0
     action_duration: float = 0.0   # berekend op moment van action-start
+    stop_triggered: bool = False   # voor audio: fade-out al ingezet?
 
 
 class PlaybackController(QObject):
@@ -122,6 +123,7 @@ class PlaybackController(QObject):
                 loops=cue.loops,
                 start_offset=cue.audio_start_offset,
                 end_offset=cue.audio_end_offset,
+                fade_in=cue.audio_fade_in,
             )
             if not ok:
                 r.action_duration = 0.0
@@ -208,23 +210,41 @@ class PlaybackController(QObject):
             elif r.phase == "action":
                 finished = False
                 if r.cue.cue_type == CueType.AUDIO:
+                    # Bepaal wanneer de "main playback" eindigt (expliciete
+                    # duration óf natuurlijk einde van het bestand).
+                    main_done = False
                     if r.action_duration > 0:
                         if elapsed_phase >= r.action_duration:
-                            finished = True
+                            main_done = True
                     else:
+                        if not self.audio.is_playing(r.cue.id):
+                            main_done = True
+
+                    if main_done and not r.stop_triggered:
+                        self.audio.stop_cue(r.cue.id, fade_out=r.cue.audio_fade_out)
+                        r.stop_triggered = True
+                        # AUTO_FOLLOW moet hier al triggeren zodat de volgende
+                        # cue start terwijl deze uitfadet — dat geeft de
+                        # gewenste crossfade.
+                        if r.cue.continue_mode == ContinueMode.AUTO_FOLLOW:
+                            to_advance.append(cid)
+                        if r.cue.audio_fade_out <= 0:
+                            finished = True
+                    elif r.stop_triggered:
+                        # Wacht tot fade-out klaar is voor we post_wait ingaan.
                         if not self.audio.is_playing(r.cue.id):
                             finished = True
                 else:
                     if elapsed_phase >= r.action_duration:
                         finished = True
+                        # Niet-audio: AUTO_FOLLOW triggert hier.
+                        if r.cue.continue_mode == ContinueMode.AUTO_FOLLOW:
+                            to_advance.append(cid)
 
                 if finished:
                     r.phase = "post_wait"
                     r.phase_started_at = now
-                    # Auto-follow: volgende cue start ná de actie
-                    if r.cue.continue_mode == ContinueMode.AUTO_FOLLOW:
-                        to_advance.append(cid)
-                    # Audio engine cleanup
+                    # Zorg dat er niets blijft hangen in de mixer.
                     if r.cue.cue_type == CueType.AUDIO:
                         self.audio.stop_cue(r.cue.id)
 

--- a/livefire/ui/inspector.py
+++ b/livefire/ui/inspector.py
@@ -110,10 +110,14 @@ class InspectorWidget(QWidget):
         self.sp_loops.setSpecialValueText("∞")
         self.sp_start = self._spin_seconds()
         self.sp_end = self._spin_seconds()
+        self.sp_fade_in = self._spin_seconds(max_val=600.0)
+        self.sp_fade_out = self._spin_seconds(max_val=600.0)
         al.addRow("Volume", self.sp_volume)
         al.addRow("Loops (0 = ∞)", self.sp_loops)
         al.addRow("Start-offset (s)", self.sp_start)
         al.addRow("Eind-offset (s)", self.sp_end)
+        al.addRow("Fade-in (s)", self.sp_fade_in)
+        al.addRow("Fade-out (s)", self.sp_fade_out)
         lay.addWidget(self.grp_audio)
 
         # ---- Wait ----------------------------------------------------------
@@ -151,7 +155,8 @@ class InspectorWidget(QWidget):
             else:
                 w.textChanged.connect(self._on_any_change)
         for w in (self.sp_pre, self.sp_dur, self.sp_post, self.sp_volume,
-                  self.sp_start, self.sp_end, self.sp_wait, self.sp_fade_target):
+                  self.sp_start, self.sp_end, self.sp_fade_in, self.sp_fade_out,
+                  self.sp_wait, self.sp_fade_target):
             w.valueChanged.connect(self._on_any_change)
         self.sp_loops.valueChanged.connect(self._on_any_change)
         self.cb_type.currentTextChanged.connect(self._on_type_change)
@@ -230,6 +235,8 @@ class InspectorWidget(QWidget):
         self.sp_loops.setValue(cue.loops)
         self.sp_start.setValue(cue.audio_start_offset)
         self.sp_end.setValue(cue.audio_end_offset)
+        self.sp_fade_in.setValue(cue.audio_fade_in)
+        self.sp_fade_out.setValue(cue.audio_fade_out)
         self.sp_wait.setValue(cue.wait_duration)
         self.sp_fade_target.setValue(cue.fade_target_db)
         self.chk_fade_stops.setChecked(cue.fade_stops_target)
@@ -271,6 +278,8 @@ class InspectorWidget(QWidget):
         c.loops = self.sp_loops.value()
         c.audio_start_offset = self.sp_start.value()
         c.audio_end_offset = self.sp_end.value()
+        c.audio_fade_in = self.sp_fade_in.value()
+        c.audio_fade_out = self.sp_fade_out.value()
         c.wait_duration = self.sp_wait.value()
         c.fade_target_db = self.sp_fade_target.value()
         c.fade_stops_target = self.chk_fade_stops.isChecked()

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -52,3 +52,43 @@ def test_set_device_on_stopped_engine_updates_config():
     assert ok, err
     assert eng.sample_rate == 44100
     assert eng.device is None
+
+
+def test_audio_source_fade_in_ramps_from_silence():
+    """Een AudioSource met fade_in_s > 0 start bij 0.0 en ramped naar het
+    volume-doel — zodat overlappende cues een natuurlijke crossfade geven."""
+    import numpy as np
+    from livefire.engines.audio import AudioSource
+
+    sr = 48000
+    frames = sr  # 1 s mono->stereo signaal op volle sterkte
+    samples = np.ones((frames, 2), dtype=np.float32)
+
+    src = AudioSource(
+        cue_id="x", samples=samples, sample_rate=sr,
+        volume_db=0.0, loops=1, fade_in_s=0.5,
+    )
+    # Eerste sample vlak na start: gain ≈ 0 → output ≈ 0
+    out = src.read(1, 2)
+    assert abs(out[0, 0]) < 0.01, f"start van fade-in niet stil: {out[0, 0]}"
+
+    # Na de volledige fade-in-duur: gain op target (1.0) → output ≈ 1.0
+    src2 = AudioSource(
+        cue_id="y", samples=samples, sample_rate=sr,
+        volume_db=0.0, loops=1, fade_in_s=0.5,
+    )
+    _ = src2.read(int(0.5 * sr), 2)   # eet de fade-in op
+    tail = src2.read(100, 2)
+    assert tail[0, 0] > 0.95, f"eind van fade-in niet op target: {tail[0, 0]}"
+
+
+def test_audio_source_no_fade_in_plays_at_volume_immediately():
+    import numpy as np
+    from livefire.engines.audio import AudioSource
+
+    sr = 48000
+    samples = np.ones((sr, 2), dtype=np.float32)
+    src = AudioSource(cue_id="z", samples=samples, sample_rate=sr,
+                      volume_db=0.0, loops=1, fade_in_s=0.0)
+    out = src.read(10, 2)
+    assert out[0, 0] > 0.99, f"zonder fade-in niet direct op volume: {out[0, 0]}"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -15,7 +15,8 @@ from livefire.workspace import Workspace
 def test_roundtrip_preserves_all_cue_types(tmp_path: Path):
     ws = Workspace(name="roundtrip")
     ws.add_cue(Cue(cue_type=CueType.AUDIO, name="intro", volume_db=-6.0,
-                   loops=2, audio_start_offset=0.5))
+                   loops=2, audio_start_offset=0.5,
+                   audio_fade_in=1.5, audio_fade_out=2.0))
     ws.add_cue(Cue(cue_type=CueType.WAIT, name="pauze", wait_duration=3.0))
     target = ws.cues[0].id
     ws.add_cue(Cue(cue_type=CueType.FADE, name="outfade",
@@ -43,6 +44,8 @@ def test_roundtrip_preserves_all_cue_types(tmp_path: Path):
         assert orig.target_cue_id == got.target_cue_id
         assert orig.fade_stops_target == got.fade_stops_target
         assert orig.continue_mode == got.continue_mode
+        assert orig.audio_fade_in == got.audio_fade_in
+        assert orig.audio_fade_out == got.audio_fade_out
 
 
 def test_save_writes_current_format_version(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Audio-cues krijgen `audio_fade_in` en `audio_fade_out` (s) in de inspector, meegenomen in workspace-roundtrip.
- `AudioSource` start bij 0.0 gain als `fade_in_s > 0` en rampled naar `volume_db`.
- `AudioEngine.stop_cue(fade_out=)` triggert `apply_fade(-120 dB, stops=True)` — source blijft tijdens de fade in de mixer zodat overlap met een nieuwe cue een natuurlijke crossfade geeft.
- `PlaybackController` triggert AUTO_FOLLOW op het moment dat de main-playback van een audio-cue eindigt (niet pas na fade-out), zodat de volgende cue start terwijl deze uitfadet. `post_wait` begint pas nadat de fade-out klaar is.

## Bonus
- `.claude/` toegevoegd aan `.gitignore` (lokale Claude Code permissions).

## Test plan
- [x] pytest: 13/13 groen (incl. 2 nieuwe AudioSource fade-in tests + workspace-roundtrip van nieuwe velden)
- [x] App start zonder traceback
- [ ] Visueel getest met audio-bestand (fade-in/out + crossfade bij AUTO_FOLLOW) — user skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)