### PR TITLE
feat(osc): OSC-input voor cue-triggering (v0.4.0 stap 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Alle noemenswaardige wijzigingen aan dit project. Format volgens
 ## [Unreleased]
 
 ### Toegevoegd
+- **OSC-input** voor cue-triggering vanaf Companion / Stream Deck / externe
+  consoles. Elke cue krijgt een optioneel `trigger_osc` veld (bv.
+  `/livefire/go/intro`); inkomende OSC-messages met dezelfde address vuren
+  de cue af via `PlaybackController.fire_cue()`. UDP-poort en enable-flag
+  zijn instelbaar via Voorkeuren (standaard 53000, default uit). Nieuwe
+  `OscInputEngine` draait in een daemon-thread met een Qt-signal zodat
+  de UI-thread de messages netjes opvangt.
+- "Learn…"-knop in de inspector bij het OSC-trigger-veld: wacht op de
+  eerstvolgende OSC-message en vult hem automatisch in.
+- `python-osc` toegevoegd aan `requirements.txt` (pure Python, geen
+  build-tools nodig).
 - Per-cue **Fade-in** en **Fade-out** (s) op Audio-cues in de inspector.
   Overlappende audio-cues geven hiermee een natuurlijke crossfade: bij
   AUTO_FOLLOW start de volgende cue zodra de main-playback van de huidige

--- a/livefire/cues/base.py
+++ b/livefire/cues/base.py
@@ -82,6 +82,9 @@ class Cue:
     # Groepsgedrag
     group_mode: str = "list"   # "list" | "first-then-list"
 
+    # Triggers (v0.4.0)
+    trigger_osc: str = ""      # OSC-address dat deze cue afvuurt, bv. /livefire/go/intro
+
     # Runtime-only (niet geserialiseerd)
     state: str = field(default="idle", compare=False)  # idle|running|finished
 

--- a/livefire/engines/__init__.py
+++ b/livefire/engines/__init__.py
@@ -1,4 +1,5 @@
 from .audio import AudioEngine
+from .osc import OscInputEngine
 from . import registry
 
-__all__ = ["AudioEngine", "registry"]
+__all__ = ["AudioEngine", "OscInputEngine", "registry"]

--- a/livefire/engines/osc.py
+++ b/livefire/engines/osc.py
@@ -1,0 +1,139 @@
+"""OSC input-engine. Luistert op een UDP-poort en emit een Qt-signal voor
+elke inkomende message. Bedoeld om cues te triggeren vanaf Companion,
+Stream Deck, externe consoles of Max/MSP.
+
+Design:
+- python-osc's ``BlockingOSCUDPServer`` draait in een daemon-thread.
+- Een catch-all dispatcher ontvangt alle addresses en emit het Qt-signal.
+- pyqtSignal is thread-safe over thread-grenzen (auto connection type), dus
+  de UI-thread ontvangt het signal netjes via de event-loop.
+- Geen auto-start: de UI (MainWindow) start 'm met de geconfigureerde poort.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from PyQt6.QtCore import QObject, pyqtSignal
+
+from .registry import EngineStatus, register
+
+# Optionele dependency — engine werkt degraded zonder.
+try:
+    from pythonosc.dispatcher import Dispatcher
+    from pythonosc.osc_server import BlockingOSCUDPServer
+    _OSC_OK = True
+    _OSC_ERR = ""
+except Exception as e:
+    Dispatcher = None  # type: ignore[assignment]
+    BlockingOSCUDPServer = None  # type: ignore[assignment]
+    _OSC_OK = False
+    _OSC_ERR = str(e)
+
+
+DEFAULT_OSC_HOST = "0.0.0.0"
+DEFAULT_OSC_PORT = 53000
+
+
+class OscInputEngine(QObject):
+    """Luistert op een UDP-poort; emit ``message_received(address, args)``.
+
+    - ``address`` is de OSC-address (bv. ``/livefire/go/intro``).
+    - ``args`` is een tuple met alle argumenten (kan leeg zijn).
+    """
+
+    message_received = pyqtSignal(str, tuple)
+
+    def __init__(self, parent: QObject | None = None):
+        super().__init__(parent)
+        self._server: "BlockingOSCUDPServer | None" = None
+        self._thread: threading.Thread | None = None
+        self._host: str = DEFAULT_OSC_HOST
+        self._port: int = 0
+        self._last_error: str = ""
+
+    # ---- lifecycle ---------------------------------------------------------
+
+    @property
+    def available(self) -> bool:
+        return _OSC_OK
+
+    @property
+    def running(self) -> bool:
+        return self._server is not None
+
+    @property
+    def port(self) -> int:
+        return self._port
+
+    @property
+    def last_error(self) -> str:
+        return self._last_error
+
+    def start(self, port: int, host: str = DEFAULT_OSC_HOST) -> tuple[bool, str]:
+        """Start de server op (host, port). Stopt eerst als er al een draait."""
+        if not self.available:
+            return False, _OSC_ERR
+        self.stop()
+        try:
+            dispatcher = Dispatcher()  # type: ignore[misc]
+            dispatcher.set_default_handler(self._on_osc)
+            server = BlockingOSCUDPServer((host, port), dispatcher)  # type: ignore[misc]
+        except Exception as e:
+            self._last_error = str(e)
+            return False, str(e)
+        self._server = server
+        self._host = host
+        self._port = port
+        self._thread = threading.Thread(
+            target=server.serve_forever, name="osc-input", daemon=True,
+        )
+        self._thread.start()
+        self._last_error = ""
+        return True, ""
+
+    def stop(self) -> None:
+        if self._server is not None:
+            try:
+                self._server.shutdown()
+                self._server.server_close()
+            except Exception:
+                pass
+        self._server = None
+        self._thread = None
+        self._port = 0
+
+    # ---- intern ------------------------------------------------------------
+
+    def _on_osc(self, address: str, *args: Any) -> None:
+        """Catch-all handler — draait op de osc-thread. pyqtSignal zorgt voor
+        de queued delivery naar de UI-thread."""
+        self.message_received.emit(address, tuple(args))
+
+
+# ---- status-registratie ----------------------------------------------------
+
+def register_status(engine: OscInputEngine | None = None) -> None:
+    if not _OSC_OK:
+        register(EngineStatus(
+            name="OSC-input",
+            available=False,
+            detail=f"python-osc ontbreekt: {_OSC_ERR}",
+            short="osc",
+        ))
+        return
+    if engine is None or not engine.running:
+        register(EngineStatus(
+            name="OSC-input",
+            available=True,
+            detail="niet gestart",
+            short="osc",
+        ))
+        return
+    register(EngineStatus(
+        name="OSC-input",
+        available=True,
+        detail=f"luistert op {engine._host}:{engine.port}",
+        short="osc",
+    ))

--- a/livefire/playback/controller.py
+++ b/livefire/playback/controller.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from PyQt6.QtCore import QObject, QTimer, pyqtSignal
 
 from ..cues import Cue, CueType, ContinueMode
-from ..engines import AudioEngine
+from ..engines import AudioEngine, OscInputEngine
 from ..workspace import Workspace
 
 
@@ -43,11 +43,15 @@ class PlaybackController(QObject):
         workspace: Workspace,
         parent: QObject | None = None,
         audio: AudioEngine | None = None,
+        osc: OscInputEngine | None = None,
     ):
         super().__init__(parent)
         self.workspace = workspace
         self.audio = audio if audio is not None else AudioEngine()
         self.audio.start()
+
+        self.osc = osc if osc is not None else OscInputEngine(self)
+        self.osc.message_received.connect(self._on_osc_message)
 
         self._running: dict[str, _Running] = {}
         self._playhead_index: int = 0
@@ -68,6 +72,7 @@ class PlaybackController(QObject):
         self._timer.stop()
         self.stop_all()
         self.audio.stop()
+        self.osc.stop()
 
     # ---- transport ---------------------------------------------------------
 
@@ -85,6 +90,23 @@ class PlaybackController(QObject):
         cue = self.workspace.cues[self._playhead_index]
         self._playhead_index += 1
         self._start_cue(cue)
+
+    def fire_cue(self, cue_id: str) -> bool:
+        """Start een specifieke cue zonder de playhead te verplaatsen
+        (voor externe triggers zoals OSC/MIDI)."""
+        cue = self.workspace.find(cue_id)
+        if cue is None:
+            return False
+        self._start_cue(cue)
+        return True
+
+    # ---- trigger-matching --------------------------------------------------
+
+    def _on_osc_message(self, address: str, _args: tuple) -> None:
+        """Op inkomende OSC: vind cues met trigger_osc == address en vuur ze."""
+        for cue in self.workspace.cues:
+            if cue.trigger_osc and cue.trigger_osc == address:
+                self.fire_cue(cue.id)
 
     def stop_all(self) -> None:
         ids = list(self._running.keys())

--- a/livefire/ui/dialogs/preferences.py
+++ b/livefire/ui/dialogs/preferences.py
@@ -7,13 +7,15 @@ from __future__ import annotations
 from PyQt6.QtCore import QSettings
 from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QFormLayout, QComboBox, QDialogButtonBox, QGroupBox,
-    QLabel, QMessageBox,
+    QLabel, QMessageBox, QSpinBox, QCheckBox,
 )
 
 from ...engines.audio import (
     AudioEngine, list_output_devices, find_device_index_by_name,
 )
 from ...engines.audio import register_status as register_audio_status
+from ...engines.osc import OscInputEngine, DEFAULT_OSC_PORT
+from ...engines.osc import register_status as register_osc_status
 
 
 SUPPORTED_SAMPLE_RATES = [44100, 48000, 96000]
@@ -23,9 +25,15 @@ DEFAULT_SAMPLE_RATE = 48000
 class PreferencesDialog(QDialog):
     """Dialog voor app-brede voorkeuren (nu: audio-device + samplerate)."""
 
-    def __init__(self, engine: AudioEngine, parent=None):
+    def __init__(
+        self,
+        engine: AudioEngine,
+        osc: OscInputEngine | None = None,
+        parent=None,
+    ):
         super().__init__(parent)
         self.engine = engine
+        self.osc = osc
         self.setWindowTitle("Voorkeuren")
         self.setMinimumWidth(440)
 
@@ -50,6 +58,17 @@ class PreferencesDialog(QDialog):
         form.addRow(self.lbl_hint)
 
         root.addWidget(grp)
+
+        # ---- OSC -----------------------------------------------------------
+        grp_osc = QGroupBox("OSC-input")
+        osc_form = QFormLayout(grp_osc)
+        self.chk_osc_enabled = QCheckBox("OSC-input inschakelen")
+        self.sp_osc_port = QSpinBox()
+        self.sp_osc_port.setRange(1, 65535)
+        self.sp_osc_port.setValue(DEFAULT_OSC_PORT)
+        osc_form.addRow(self.chk_osc_enabled)
+        osc_form.addRow("UDP-poort", self.sp_osc_port)
+        root.addWidget(grp_osc)
 
         # Waarden uit QSettings (of huidige engine-config als fallback).
         self._load_from_settings()
@@ -91,6 +110,13 @@ class PreferencesDialog(QDialog):
             sr_idx = self.cb_samplerate.findData(DEFAULT_SAMPLE_RATE)
         self.cb_samplerate.setCurrentIndex(max(0, sr_idx))
 
+        self.chk_osc_enabled.setChecked(
+            s.value("osc/enabled", False, type=bool)
+        )
+        self.sp_osc_port.setValue(
+            s.value("osc/port", DEFAULT_OSC_PORT, type=int)
+        )
+
     # ---- apply -------------------------------------------------------------
 
     def _apply_and_accept(self) -> None:
@@ -128,5 +154,23 @@ class PreferencesDialog(QDialog):
         # Engine-status registry bijwerken zodat statusbar en Engine-status
         # dialog het nieuwe device tonen.
         register_audio_status(self.engine)
+
+        # OSC toepassen
+        if self.osc is not None:
+            osc_enabled = self.chk_osc_enabled.isChecked()
+            osc_port = int(self.sp_osc_port.value())
+            self.osc.stop()
+            osc_detail = ""
+            if osc_enabled:
+                ok, err = self.osc.start(osc_port)
+                if not ok:
+                    QMessageBox.warning(
+                        self, "Kan OSC-input niet starten",
+                        f"{err}\n\nOSC blijft uit.",
+                    )
+                    osc_enabled = False
+            s.setValue("osc/enabled", bool(osc_enabled))
+            s.setValue("osc/port", osc_port)
+            register_osc_status(self.osc)
 
         self.accept()

--- a/livefire/ui/dialogs/trigger_learn.py
+++ b/livefire/ui/dialogs/trigger_learn.py
@@ -1,0 +1,55 @@
+"""Modal die wacht op de volgende OSC-message en 'm als trigger-address
+teruggeeft. Sluit automatisch zodra er iets binnenkomt."""
+
+from __future__ import annotations
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QDialogButtonBox
+
+from ...engines.osc import OscInputEngine
+
+
+class OscLearnDialog(QDialog):
+    """Toont 'Wacht op OSC-input…' en vult zichzelf met de eerste address
+    die binnenkomt."""
+
+    def __init__(self, engine: OscInputEngine, parent=None):
+        super().__init__(parent)
+        self.engine = engine
+        self.learned_address: str = ""
+
+        self.setWindowTitle("OSC-trigger leren")
+        self.setMinimumWidth(360)
+
+        lay = QVBoxLayout(self)
+
+        self.lbl_status = QLabel(
+            f"Wacht op OSC-input op poort {engine.port}…\n\n"
+            "Stuur nu een OSC-message vanaf je console (bv. Companion)."
+        )
+        self.lbl_status.setWordWrap(True)
+        self.lbl_status.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        lay.addWidget(self.lbl_status)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Cancel)
+        buttons.rejected.connect(self.reject)
+        lay.addWidget(buttons)
+
+        self.engine.message_received.connect(self._on_message)
+
+    def _on_message(self, address: str, _args: tuple) -> None:
+        self.learned_address = address
+        self.lbl_status.setText(f"Ontvangen: {address}\n\nDialog sluit automatisch.")
+        # Disconnect zodat we maar één message pakken.
+        try:
+            self.engine.message_received.disconnect(self._on_message)
+        except TypeError:
+            pass
+        self.accept()
+
+    def reject(self) -> None:
+        try:
+            self.engine.message_received.disconnect(self._on_message)
+        except TypeError:
+            pass
+        super().reject()

--- a/livefire/ui/inspector.py
+++ b/livefire/ui/inspector.py
@@ -138,6 +138,21 @@ class InspectorWidget(QWidget):
         tl.addRow("", self.chk_fade_stops)
         lay.addWidget(self.grp_target)
 
+        # ---- Triggers ------------------------------------------------------
+        self.grp_triggers = QGroupBox("Triggers")
+        trg = QFormLayout(self.grp_triggers)
+        osc_row = QHBoxLayout()
+        self.ed_trigger_osc = QLineEdit()
+        self.ed_trigger_osc.setPlaceholderText("/livefire/go/intro — leeg = geen trigger")
+        self.btn_learn_osc = QPushButton("Learn…")
+        self.btn_learn_osc.clicked.connect(self._learn_osc)
+        osc_row.addWidget(self.ed_trigger_osc)
+        osc_row.addWidget(self.btn_learn_osc)
+        osc_container = QWidget()
+        osc_container.setLayout(osc_row)
+        trg.addRow("OSC-address", osc_container)
+        lay.addWidget(self.grp_triggers)
+
         # ---- Notities ------------------------------------------------------
         grp_notes = QGroupBox("Notities")
         nl = QVBoxLayout(grp_notes)
@@ -149,7 +164,8 @@ class InspectorWidget(QWidget):
         lay.addStretch(1)
 
         # ---- wire changes --------------------------------------------------
-        for w in (self.ed_number, self.ed_name, self.ed_path, self.ed_notes):
+        for w in (self.ed_number, self.ed_name, self.ed_path, self.ed_notes,
+                  self.ed_trigger_osc):
             if isinstance(w, QPlainTextEdit):
                 w.textChanged.connect(self._on_any_change)
             else:
@@ -240,6 +256,7 @@ class InspectorWidget(QWidget):
         self.sp_wait.setValue(cue.wait_duration)
         self.sp_fade_target.setValue(cue.fade_target_db)
         self.chk_fade_stops.setChecked(cue.fade_stops_target)
+        self.ed_trigger_osc.setText(cue.trigger_osc)
         self.ed_notes.setPlainText(cue.notes)
 
         self.refresh_targets()
@@ -284,6 +301,7 @@ class InspectorWidget(QWidget):
         c.fade_target_db = self.sp_fade_target.value()
         c.fade_stops_target = self.chk_fade_stops.isChecked()
         c.target_cue_id = self.cb_target.currentData() or ""
+        c.trigger_osc = self.ed_trigger_osc.text().strip()
         c.notes = self.ed_notes.toPlainText()
         self.workspace.dirty = True
         self.cue_changed.emit(c)
@@ -310,3 +328,22 @@ class InspectorWidget(QWidget):
         )
         if path:
             self.ed_path.setText(path)
+
+    # ---- trigger-learn ----------------------------------------------------
+
+    osc_engine = None  # wordt door MainWindow gezet: inspector.osc_engine = …
+
+    def _learn_osc(self) -> None:
+        """Open een modal die wacht op de volgende OSC-message en 'm invult."""
+        from .dialogs.trigger_learn import OscLearnDialog
+        if self.osc_engine is None or not self.osc_engine.running:
+            from PyQt6.QtWidgets import QMessageBox
+            QMessageBox.warning(
+                self, "OSC niet actief",
+                "De OSC-input engine draait niet. Zet 'm aan via Voorkeuren…"
+                " en stuur dan nogmaals.",
+            )
+            return
+        dlg = OscLearnDialog(self.osc_engine, self)
+        if dlg.exec() and dlg.learned_address:
+            self.ed_trigger_osc.setText(dlg.learned_address)

--- a/livefire/ui/mainwindow.py
+++ b/livefire/ui/mainwindow.py
@@ -21,12 +21,13 @@ from ..engines.audio import (
     register_status as register_audio_status,
     find_device_index_by_name,
 )
+from ..engines.osc import register_status as register_osc_status
 
 from .cuelist import CueListWidget
 from .inspector import InspectorWidget
 from .transport import TransportWidget
 from .dialogs import show_about, EngineStatusDialog, PreferencesDialog
-from .dialogs.preferences import DEFAULT_SAMPLE_RATE
+from .dialogs.preferences import DEFAULT_SAMPLE_RATE, DEFAULT_OSC_PORT
 
 
 class MainWindow(QMainWindow):
@@ -47,14 +48,21 @@ class MainWindow(QMainWindow):
         self.controller.cue_state_changed.connect(self._on_cue_state_changed)
         self.controller.running_changed.connect(self._on_running_changed)
 
+        # OSC-input opstarten vanuit QSettings
+        self._start_osc_from_settings()
+
         # Engine status registreren
         register_audio_status(self.controller.audio)
+        register_osc_status(self.controller.osc)
 
         # UI
         self._build_ui()
         self._build_menu()
         self._build_shortcuts()
         self._sync_title()
+
+        # Inspector krijgt een handle naar de OSC-engine voor de Learn-dialog
+        self.inspector.osc_engine = self.controller.osc
 
     # ---- build ------------------------------------------------------------
 
@@ -265,7 +273,7 @@ class MainWindow(QMainWindow):
         dlg.exec()
 
     def action_preferences(self) -> None:
-        dlg = PreferencesDialog(self.controller.audio, self)
+        dlg = PreferencesDialog(self.controller.audio, self.controller.osc, self)
         if dlg.exec():
             self._refresh_statusbar()
 
@@ -281,6 +289,18 @@ class MainWindow(QMainWindow):
         sr = s.value("audio/samplerate", DEFAULT_SAMPLE_RATE, type=int)
         device = find_device_index_by_name(device_name) if device_name else None
         return AudioEngine(sample_rate=sr, device=device)
+
+    def _start_osc_from_settings(self) -> None:
+        s = QSettings()
+        if not s.value("osc/enabled", False, type=bool):
+            return
+        port = s.value("osc/port", DEFAULT_OSC_PORT, type=int)
+        ok, err = self.controller.osc.start(int(port))
+        if not ok:
+            QMessageBox.warning(
+                self, "OSC-input niet gestart",
+                f"Kon OSC niet starten op poort {port}: {err}",
+            )
 
     # ---- reactive handlers ------------------------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,14 +7,13 @@ soundfile>=0.12
 numpy>=1.26
 scipy>=1.12          # resample_poly voor sample-rate conversion
 
-# MIDI / OSC — pas nodig vanaf v0.4.0 (cue-triggering vanaf Companion/StreamDeck).
-# Uitgecommentarieerd omdat python-rtmidi op Python 3.14 nog geen prebuilt wheel
-# heeft en dus MSVC Build Tools zou vereisen. Terug aanzetten zodra we OSC-in
-# en MIDI-in implementeren — dan ook checken of er inmiddels wheels zijn of dat
-# we naar een andere Python-versie moeten zakken voor de installer-build.
+# MIDI / OSC — cue-triggering vanaf Companion / Stream Deck / externe consoles.
+# python-osc is pure Python en werkt zonder build-tools (v0.4.0 OSC-in).
+# mido + python-rtmidi komen in v0.4.x bij MIDI-in (python-rtmidi heeft op
+# Python 3.14 geen prebuilt wheel; dan evt. terugzakken naar 3.11).
+python-osc>=1.8
 # mido>=1.3
 # python-rtmidi>=1.5
-# python-osc>=1.8
 
 # Optioneel nog uit te werken in komende versies:
 # pyartnet>=0.8      # DMX Art-Net (v0.5)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Gedeelde pytest-fixtures."""
+
+from __future__ import annotations
+
+import pytest
+
+from PyQt6.QtWidgets import QApplication
+
+
+@pytest.fixture(scope="session")
+def qt_app():
+    """Eén QApplication voor de hele testsessie — QObject/pyqtSignal werken
+    alleen binnen een QApplication-context. Terug te gebruiken over meerdere
+    tests heen (QApplication kan maar één keer bestaan per proces)."""
+    app = QApplication.instance() or QApplication([])
+    yield app

--- a/tests/test_osc.py
+++ b/tests/test_osc.py
@@ -1,0 +1,130 @@
+"""Tests voor OscInputEngine en trigger-matching. We starten een echte
+UDP-server op een vrije localhost-poort, sturen een OSC-message via
+python-osc's UDP-client, en verifiëren dat het Qt-signal aangekomen is
+en dat de matcher de juiste cue afvuurt."""
+
+from __future__ import annotations
+
+import socket
+import time
+from typing import List, Tuple
+
+import pytest
+
+from livefire.cues import Cue, CueType
+from livefire.engines.osc import OscInputEngine
+from livefire.workspace import Workspace
+
+
+def _free_udp_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def test_osc_engine_receives_message(qt_app):
+    """Start de engine, stuur een OSC-message, verwacht dat message_received
+    emit met (address, args)."""
+    pytest.importorskip("pythonosc")
+    from pythonosc.udp_client import SimpleUDPClient
+
+    eng = OscInputEngine()
+    port = _free_udp_port()
+    ok, err = eng.start(port, host="127.0.0.1")
+    assert ok, err
+
+    received: List[Tuple[str, tuple]] = []
+    eng.message_received.connect(lambda addr, args: received.append((addr, args)))
+
+    try:
+        client = SimpleUDPClient("127.0.0.1", port)
+        client.send_message("/livefire/go/intro", [])
+
+        # Wacht tot Qt-eventloop het signal heeft afgeleverd
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and not received:
+            qt_app.processEvents()
+            time.sleep(0.02)
+    finally:
+        eng.stop()
+
+    assert received, "geen OSC-message ontvangen"
+    assert received[0][0] == "/livefire/go/intro"
+
+
+def test_trigger_matcher_fires_matching_cue():
+    """PlaybackController._on_osc_message moet cues met gelijke trigger_osc
+    afvuren via fire_cue()."""
+    # We mocken PlaybackController's dependency via Workspace + fire_cue stub.
+    from livefire.playback.controller import PlaybackController
+
+    class _Stub(PlaybackController):
+        def __init__(self, ws):
+            # Skip __init__ van echte controller (wil Qt + audio + osc).
+            # We roepen QObject direct aan om de signals te vermijden.
+            from PyQt6.QtCore import QObject
+            QObject.__init__(self)
+            self.workspace = ws
+            self.fired: list[str] = []
+
+        def fire_cue(self, cue_id: str) -> bool:  # type: ignore[override]
+            self.fired.append(cue_id)
+            return True
+
+    ws = Workspace()
+    ws.add_cue(Cue(cue_type=CueType.MEMO, name="a",
+                   trigger_osc="/livefire/go/a"))
+    ws.add_cue(Cue(cue_type=CueType.MEMO, name="b",
+                   trigger_osc="/livefire/go/b"))
+    ws.add_cue(Cue(cue_type=CueType.MEMO, name="c"))  # geen trigger
+
+    ctrl = _Stub(ws)
+    ctrl._on_osc_message("/livefire/go/b", ())
+
+    assert ctrl.fired == [ws.cues[1].id]
+
+
+def test_trigger_matcher_no_match_is_noop():
+    from livefire.playback.controller import PlaybackController
+
+    class _Stub(PlaybackController):
+        def __init__(self, ws):
+            from PyQt6.QtCore import QObject
+            QObject.__init__(self)
+            self.workspace = ws
+            self.fired: list[str] = []
+
+        def fire_cue(self, cue_id: str) -> bool:  # type: ignore[override]
+            self.fired.append(cue_id)
+            return True
+
+    ws = Workspace()
+    ws.add_cue(Cue(cue_type=CueType.MEMO, name="a",
+                   trigger_osc="/livefire/go/a"))
+    ctrl = _Stub(ws)
+    ctrl._on_osc_message("/niet/bestaand", ())
+    assert ctrl.fired == []
+
+
+def test_trigger_matcher_ignores_empty_trigger():
+    """Een cue zonder trigger_osc moet nooit matchen, ook niet met lege address."""
+    from livefire.playback.controller import PlaybackController
+
+    class _Stub(PlaybackController):
+        def __init__(self, ws):
+            from PyQt6.QtCore import QObject
+            QObject.__init__(self)
+            self.workspace = ws
+            self.fired: list[str] = []
+
+        def fire_cue(self, cue_id: str) -> bool:  # type: ignore[override]
+            self.fired.append(cue_id)
+            return True
+
+    ws = Workspace()
+    ws.add_cue(Cue(cue_type=CueType.MEMO, name="a"))  # trigger_osc=""
+    ctrl = _Stub(ws)
+    ctrl._on_osc_message("", ())
+    assert ctrl.fired == []

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -28,7 +28,8 @@ def test_roundtrip_preserves_all_cue_types(tmp_path: Path):
                    notes="Toegang niet vergeten!"))
     ws.add_cue(Cue(cue_type=CueType.START, name="start",
                    target_cue_id=target,
-                   continue_mode=ContinueMode.AUTO_CONTINUE))
+                   continue_mode=ContinueMode.AUTO_CONTINUE,
+                   trigger_osc="/livefire/go/start"))
 
     p = tmp_path / "test.livefire"
     ws.save(p)
@@ -46,6 +47,7 @@ def test_roundtrip_preserves_all_cue_types(tmp_path: Path):
         assert orig.continue_mode == got.continue_mode
         assert orig.audio_fade_in == got.audio_fade_in
         assert orig.audio_fade_out == got.audio_fade_out
+        assert orig.trigger_osc == got.trigger_osc
 
 
 def test_save_writes_current_format_version(tmp_path: Path):


### PR DESCRIPTION
## Summary
- **`OscInputEngine`** (QObject) luistert op een UDP-poort in een daemon-thread, emit `message_received(address, args)` via pyqtSignal — Qt-thread-safe.
- **`Cue.trigger_osc`** veld + matcher in `PlaybackController._on_osc_message` die cues met matching address afvuurt via nieuwe `fire_cue()` API (bypass playhead).
- **Inspector**: "Triggers"-groep met OSC-address veld + **Learn…**-knop (modal wacht op eerstvolgende OSC-message).
- **Voorkeuren-dialog**: OSC-enable + UDP-poort (default 53000), persistent via QSettings.
- **Engine-status** registry toont OSC-status in statusbar / dialog.
- **`python-osc`** als dependency (pure Python, geen build-tools).

## Out of scope
- MIDI-in komt in `feature/midi-input` (heeft native deps via python-rtmidi).
- MIDI/OSC-out cue-types (v0.4.x+).

## Test plan
- [x] pytest: 17/17 groen (4 nieuwe OSC-tests — UDP-roundtrip, matcher match/no-match/empty, workspace-roundtrip)
- [x] App start met `osc/enabled=true` bindt correct op configured poort
- [ ] Visueel getest met Companion / Stream Deck — user TBD

🤖 Generated with [Claude Code](https://claude.com/claude-code)