### PR TITLE
feat(ui): QLab-stijl toolbar boven de cuelist

### DIFF
--- a/livefire/ui/cuelist.py
+++ b/livefire/ui/cuelist.py
@@ -199,14 +199,14 @@ class CueListWidget(QTreeWidget):
         # Ctrl+Up/Down = verplaats
         if e.modifiers() & Qt.KeyboardModifier.ControlModifier:
             if e.key() == Qt.Key.Key_Up:
-                self._move_selected(-1)
+                self.move_selected(-1)
                 return
             if e.key() == Qt.Key.Key_Down:
-                self._move_selected(1)
+                self.move_selected(1)
                 return
         super().keyPressEvent(e)
 
-    def _move_selected(self, delta: int) -> None:
+    def move_selected(self, delta: int) -> None:
         cues = self.selected_cues()
         if not cues:
             return

--- a/livefire/ui/cuetoolbar.py
+++ b/livefire/ui/cuetoolbar.py
@@ -1,0 +1,113 @@
+"""QLab-stijl toolbar boven de cuelist: knoppen voor nieuwe cues van elk
+type + delete / renumber / move. Emit signals; de MainWindow koppelt ze
+aan de bestaande actions."""
+
+from __future__ import annotations
+
+from PyQt6.QtCore import pyqtSignal, Qt, QSize
+from PyQt6.QtGui import QColor, QIcon, QPixmap
+from PyQt6.QtWidgets import (
+    QWidget, QHBoxLayout, QPushButton, QFrame, QToolButton,
+)
+
+from ..cues import CueType
+
+
+# QLab gebruikt per cue-type een eigen kleur-accent. We doen hetzelfde zodat
+# de knoppen meteen herkenbaar zijn.
+_CUE_TYPE_ACCENTS = {
+    CueType.AUDIO:  "#2980b9",  # blauw
+    CueType.FADE:   "#c9a227",  # geel
+    CueType.WAIT:   "#606060",  # grijs
+    CueType.STOP:   "#c0392b",  # rood
+    CueType.START:  "#2e8b57",  # groen
+    CueType.GROUP:  "#7d3c98",  # paars
+    CueType.MEMO:   "#d35400",  # oranje
+}
+
+_CUE_TYPE_ORDER = [
+    CueType.AUDIO, CueType.FADE, CueType.WAIT, CueType.STOP,
+    CueType.START, CueType.GROUP, CueType.MEMO,
+]
+
+_CUE_TYPE_TIPS = {
+    CueType.AUDIO: "Nieuwe Audio-cue (Ctrl+1)",
+    CueType.FADE:  "Nieuwe Fade-cue (Ctrl+2)",
+    CueType.WAIT:  "Nieuwe Wait-cue (Ctrl+3)",
+    CueType.STOP:  "Nieuwe Stop-cue (Ctrl+4)",
+    CueType.GROUP: "Nieuwe Group-cue (Ctrl+5)",
+    CueType.MEMO:  "Nieuwe Memo-cue (Ctrl+6)",
+    CueType.START: "Nieuwe Start-cue (Ctrl+7)",
+}
+
+
+def _swatch_icon(hex_color: str, size: int = 10) -> QIcon:
+    pm = QPixmap(size, size)
+    pm.fill(QColor(hex_color))
+    return QIcon(pm)
+
+
+class CueToolbar(QWidget):
+    """Toolbar die QLab's cue-toolbar nabootst: nieuwe-cue knoppen + delete /
+    renumber / move up / move down."""
+
+    new_cue = pyqtSignal(str)       # cue_type
+    delete_selected = pyqtSignal()
+    renumber = pyqtSignal()
+    move_up = pyqtSignal()
+    move_down = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        lay = QHBoxLayout(self)
+        lay.setContentsMargins(6, 4, 6, 4)
+        lay.setSpacing(4)
+
+        for ct in _CUE_TYPE_ORDER:
+            btn = QPushButton(ct)
+            btn.setIcon(_swatch_icon(_CUE_TYPE_ACCENTS[ct]))
+            btn.setIconSize(QSize(10, 10))
+            btn.setToolTip(_CUE_TYPE_TIPS[ct])
+            btn.setFlat(False)
+            btn.setMinimumHeight(26)
+            btn.clicked.connect(lambda _checked, t=ct: self.new_cue.emit(t))
+            lay.addWidget(btn)
+
+        lay.addWidget(self._separator())
+
+        btn_del = QPushButton("Verwijderen")
+        btn_del.setToolTip("Verwijder de geselecteerde cue(s) (Delete)")
+        btn_del.setMinimumHeight(26)
+        btn_del.clicked.connect(self.delete_selected.emit)
+        lay.addWidget(btn_del)
+
+        btn_ren = QPushButton("Hernummeren")
+        btn_ren.setToolTip("Hernummer alle cues oplopend vanaf 1")
+        btn_ren.setMinimumHeight(26)
+        btn_ren.clicked.connect(self.renumber.emit)
+        lay.addWidget(btn_ren)
+
+        lay.addWidget(self._separator())
+
+        btn_up = QPushButton("↑")
+        btn_up.setToolTip("Verplaats geselecteerde cue(s) omhoog (Ctrl+↑)")
+        btn_up.setFixedWidth(32)
+        btn_up.setMinimumHeight(26)
+        btn_up.clicked.connect(self.move_up.emit)
+        lay.addWidget(btn_up)
+
+        btn_down = QPushButton("↓")
+        btn_down.setToolTip("Verplaats geselecteerde cue(s) omlaag (Ctrl+↓)")
+        btn_down.setFixedWidth(32)
+        btn_down.setMinimumHeight(26)
+        btn_down.clicked.connect(self.move_down.emit)
+        lay.addWidget(btn_down)
+
+        lay.addStretch(1)
+
+    @staticmethod
+    def _separator() -> QFrame:
+        sep = QFrame()
+        sep.setFrameShape(QFrame.Shape.VLine)
+        sep.setFrameShadow(QFrame.Shadow.Sunken)
+        return sep

--- a/livefire/ui/mainwindow.py
+++ b/livefire/ui/mainwindow.py
@@ -24,6 +24,7 @@ from ..engines.audio import (
 from ..engines.osc import register_status as register_osc_status
 
 from .cuelist import CueListWidget
+from .cuetoolbar import CueToolbar
 from .inspector import InspectorWidget
 from .transport import TransportWidget
 from .dialogs import show_about, EngineStatusDialog, PreferencesDialog
@@ -81,11 +82,27 @@ class MainWindow(QMainWindow):
         splitter = QSplitter(Qt.Orientation.Horizontal)
         vroot.addWidget(splitter, 1)
 
+        # Linkerkant: cue-toolbar boven de cuelist
+        left_side = QWidget()
+        left_layout = QVBoxLayout(left_side)
+        left_layout.setContentsMargins(0, 0, 0, 0)
+        left_layout.setSpacing(0)
+
+        self.cue_toolbar = CueToolbar()
+        self.cue_toolbar.new_cue.connect(self.action_new_cue)
+        self.cue_toolbar.delete_selected.connect(self.action_delete_selected)
+        self.cue_toolbar.renumber.connect(self.action_renumber)
+        self.cue_toolbar.move_up.connect(lambda: self.cue_list.move_selected(-1))
+        self.cue_toolbar.move_down.connect(lambda: self.cue_list.move_selected(1))
+        left_layout.addWidget(self.cue_toolbar)
+
         self.cue_list = CueListWidget(self.ws)
         self.cue_list.cue_selected.connect(self._on_cue_selected)
         self.cue_list.playhead_changed.connect(self._on_playhead_changed)
         self.cue_list.go_requested.connect(self.action_go)
-        splitter.addWidget(self.cue_list)
+        left_layout.addWidget(self.cue_list, 1)
+
+        splitter.addWidget(left_side)
 
         self.inspector = InspectorWidget(self.ws)
         self.inspector.cue_changed.connect(self._on_inspector_changed)


### PR DESCRIPTION
## Summary
- Nieuwe **CueToolbar** boven de cuelist met knoppen voor elk cue-type (Audio/Fade/Wait/Stop/Start/Group/Memo), elk met z'n eigen kleurswatch-icoon.
- Beheer-knoppen: Verwijderen / Hernummeren.
- Volgorde-knoppen: ↑ / ↓ (equivalent aan Ctrl+↑/↓).
- Alle knoppen routen naar de bestaande MainWindow-actions en cue_list-methods.

## Refactor
- `CueListWidget._move_selected` → publieke `move_selected` zodat de toolbar 'm kan aanroepen.

## Test plan
- [x] pytest 17/17 groen
- [ ] Elke knop doet hetzelfde als z'n menu-equivalent (user TBD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)