### PR TITLE
feat(ui): grote countdown-timer in de transportbalk

### DIFF
--- a/livefire/engines/audio.py
+++ b/livefire/engines/audio.py
@@ -128,6 +128,20 @@ class AudioSource:
     def channels(self) -> int:
         return self._channels
 
+    @property
+    def remaining_seconds(self) -> float:
+        """Resterende playback-tijd in seconden over alle loops heen.
+        Geeft -1.0 bij oneindige loops en 0.0 als de source klaar is."""
+        if self._finished:
+            return 0.0
+        this_loop_frames = max(0, self._effective_end - self._pos)
+        if self._loops_total == 0:  # oneindig
+            return -1.0
+        remaining_loops = max(0, self._loops_total - self._loops_done - 1)
+        full_loop_frames = max(0, self._effective_end)
+        total_frames = this_loop_frames + remaining_loops * full_loop_frames
+        return total_frames / self._sr
+
     # ---- API vanuit UI / controller thread ---------------------------------
 
     def apply_fade(self, target_db: float, duration_s: float, stops: bool = False) -> None:
@@ -400,6 +414,15 @@ class AudioEngine:
         with self._lock:
             src = self._sources.get(cue_id)
         return src is not None and not src.finished
+
+    def get_remaining(self, cue_id: str) -> float | None:
+        """Resterende playback-tijd voor deze cue. -1.0 bij oneindige loop,
+        None als de cue niet (meer) speelt."""
+        with self._lock:
+            src = self._sources.get(cue_id)
+        if src is None or src.finished:
+            return None
+        return src.remaining_seconds
 
     def active_cue_ids(self) -> list[str]:
         with self._lock:

--- a/livefire/playback/controller.py
+++ b/livefire/playback/controller.py
@@ -100,6 +100,44 @@ class PlaybackController(QObject):
         self._start_cue(cue)
         return True
 
+    def primary_countdown(self) -> tuple[str, float, bool] | None:
+        """Info voor de grote countdown-label in de transportbalk.
+
+        Retourneert ``(label, seconds, is_countdown)`` of ``None``:
+        - ``is_countdown=True`` → seconds telt af (resterend)
+        - ``is_countdown=False`` → seconds telt op (bv. bij oneindige loop)
+
+        Pakt de audio-cue in 'action'-fase met de grootste resterende tijd.
+        """
+        best: tuple[str, float, bool] | None = None
+        best_remaining = -1.0
+        for r in self._running.values():
+            if r.phase != "action":
+                continue
+            if r.cue.cue_type != CueType.AUDIO:
+                continue
+            elapsed = time.monotonic() - r.phase_started_at
+            label = r.cue.name or "(naamloos)"
+            if r.action_duration > 0:
+                remaining = max(0.0, r.action_duration - elapsed)
+                if remaining > best_remaining:
+                    best_remaining = remaining
+                    best = (label, remaining, True)
+            else:
+                src_remaining = self.audio.get_remaining(r.cue.id)
+                if src_remaining is None:
+                    continue
+                if src_remaining < 0:
+                    # Oneindige loop — count-up
+                    if elapsed > best_remaining:
+                        best_remaining = elapsed
+                        best = (label, elapsed, False)
+                else:
+                    if src_remaining > best_remaining:
+                        best_remaining = src_remaining
+                        best = (label, src_remaining, True)
+        return best
+
     # ---- trigger-matching --------------------------------------------------
 
     def _on_osc_message(self, address: str, _args: tuple) -> None:

--- a/livefire/ui/mainwindow.py
+++ b/livefire/ui/mainwindow.py
@@ -74,7 +74,9 @@ class MainWindow(QMainWindow):
         vroot.setContentsMargins(0, 0, 0, 0)
         vroot.setSpacing(0)
 
-        self.transport = TransportWidget()
+        self.transport = TransportWidget(
+            countdown_source=self.controller.primary_countdown
+        )
         self.transport.go_clicked.connect(self.action_go)
         self.transport.stop_all_clicked.connect(self.action_stop_all)
         vroot.addWidget(self.transport)

--- a/livefire/ui/transport.py
+++ b/livefire/ui/transport.py
@@ -1,16 +1,35 @@
-"""Transportbalk: GO-knop, Stop All, playhead-indicator, actieve-cue counter."""
+"""Transportbalk: GO-knop, Stop All, playhead-indicator, actieve-cue counter,
+grote countdown-timer centraal en de spelende cue-naam rechts."""
 
 from __future__ import annotations
 
-from PyQt6.QtCore import pyqtSignal, Qt
+from typing import Callable
+
+from PyQt6.QtCore import pyqtSignal, Qt, QTimer
+from PyQt6.QtGui import QFont
 from PyQt6.QtWidgets import QWidget, QHBoxLayout, QPushButton, QLabel, QFrame
+
+from .style import ACCENT, TEXT_DIM
+
+
+CountdownSource = Callable[[], "tuple[str, float, bool] | None"]
+
+
+def _fmt_time(seconds: float) -> str:
+    total = int(max(0, seconds))
+    if total >= 3600:
+        h, rem = divmod(total, 3600)
+        m, s = divmod(rem, 60)
+        return f"{h}:{m:02d}:{s:02d}"
+    m, s = divmod(total, 60)
+    return f"{m:02d}:{s:02d}"
 
 
 class TransportWidget(QWidget):
     go_clicked = pyqtSignal()
     stop_all_clicked = pyqtSignal()
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, countdown_source: CountdownSource | None = None):
         super().__init__(parent)
         lay = QHBoxLayout(self)
         lay.setContentsMargins(6, 6, 6, 6)
@@ -43,6 +62,46 @@ class TransportWidget(QWidget):
 
         lay.addStretch(1)
 
+        # ---- Countdown centraal -------------------------------------------
+        self.lbl_countdown = QLabel("—:—")
+        self.lbl_countdown.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        cd_font = QFont()
+        cd_font.setPointSize(88)
+        cd_font.setBold(True)
+        cd_font.setFamily("Consolas, Courier New, monospace")
+        self.lbl_countdown.setFont(cd_font)
+        self.lbl_countdown.setStyleSheet(f"color: {ACCENT};")
+        self.lbl_countdown.setToolTip(
+            "Resterende tijd van de langstlopende audio-cue. Bij oneindige "
+            "loop telt 'ie op (prefix +)."
+        )
+        self.lbl_countdown.setMinimumWidth(360)
+        lay.addWidget(self.lbl_countdown)
+
+        lay.addStretch(1)
+
+        # ---- Naam van de spelende cue rechts -----------------------------
+        self.lbl_countdown_name = QLabel("")
+        self.lbl_countdown_name.setAlignment(
+            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        )
+        name_font = QFont()
+        name_font.setPointSize(11)
+        self.lbl_countdown_name.setFont(name_font)
+        self.lbl_countdown_name.setStyleSheet(f"color: {TEXT_DIM};")
+        self.lbl_countdown_name.setMinimumWidth(180)
+        lay.addWidget(self.lbl_countdown_name)
+
+        # ---- Refresh-timer voor countdown ----------------------------------
+        self._countdown_source = countdown_source
+        self._cd_timer = QTimer(self)
+        self._cd_timer.setInterval(100)  # 10 Hz is ruim genoeg
+        self._cd_timer.timeout.connect(self._refresh_countdown)
+        if countdown_source is not None:
+            self._cd_timer.start()
+
+    # ---- public API --------------------------------------------------------
+
     def set_playhead(self, index: int, total: int, cue_label: str = "") -> None:
         if index >= total:
             self.lbl_playhead.setText(f"Playhead: einde ({total})")
@@ -54,3 +113,16 @@ class TransportWidget(QWidget):
 
     def set_active_count(self, n: int) -> None:
         self.lbl_active.setText(f"Actief: {n}")
+
+    # ---- countdown ---------------------------------------------------------
+
+    def _refresh_countdown(self) -> None:
+        info = self._countdown_source() if self._countdown_source else None
+        if info is None:
+            self.lbl_countdown.setText("—:—")
+            self.lbl_countdown_name.setText("")
+            return
+        name, seconds, is_countdown = info
+        prefix = "" if is_countdown else "+"
+        self.lbl_countdown.setText(f"{prefix}{_fmt_time(seconds)}")
+        self.lbl_countdown_name.setText(name)


### PR DESCRIPTION
## Summary
- **AudioSource.remaining_seconds** — resterende playback-tijd over alle loops; −1 bij oneindig, 0 bij klaar.
- **AudioEngine.get_remaining(cue_id)** — geeft de waarde door of None als cue niet (meer) speelt.
- **PlaybackController.primary_countdown()** — kiest de audio-cue in `action`-fase met grootste resterende tijd; retourneert `(label, seconds, is_countdown)`.
- **TransportWidget**: 88pt monospace ACCENT-label centraal, naam van de spelende cue rechts, 10Hz QTimer polt de source.

## Test plan
- [x] pytest 17/17 groen
- [x] Audio-cue met duration > 0 → countdown telt af
- [x] Audio-cue met duration = 0, finite loops → countdown op basis van remaining_seconds
- [x] Oneindige loop → count-up met `+` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)