### PR TITLE
feat(ui): playhead-nav via selectie + focus na GO/Stop

### DIFF
--- a/livefire/ui/cuelist.py
+++ b/livefire/ui/cuelist.py
@@ -170,6 +170,11 @@ class CueListWidget(QTreeWidget):
         for i in range(self.topLevelItemCount()):
             item = self.topLevelItem(i)
             if item.data(0, Qt.ItemDataRole.UserRole) == cue_id:
+                # ExtendedSelection: setCurrentItem alléén zet hem niet als
+                # geselecteerd. Voor keyboard-navigatie en ons playhead-from-
+                # selection-mechanisme moet de selectie ook echt op dit item.
+                self.clearSelection()
+                item.setSelected(True)
                 self.setCurrentItem(item)
                 return
 
@@ -194,6 +199,12 @@ class CueListWidget(QTreeWidget):
     def _on_selection(self) -> None:
         cues = self.selected_cues()
         self.cue_selected.emit(cues[0] if cues else None)
+        # QLab-gedrag: selectie stuurt de playhead. Enkelklik / pijltjes zetten
+        # de playhead zonder GO; dubbelklik blijft set_playhead + go_requested.
+        if cues:
+            idx = self.workspace.index_of(cues[0].id)
+            if idx >= 0 and idx != self._playhead_index:
+                self.set_playhead(idx)
 
     def _on_double_click(self, item: QTreeWidgetItem, _col: int) -> None:
         cue_id = item.data(0, Qt.ItemDataRole.UserRole)

--- a/livefire/ui/mainwindow.py
+++ b/livefire/ui/mainwindow.py
@@ -304,10 +304,17 @@ class MainWindow(QMainWindow):
         if self.controller.playhead_index >= len(self.ws.cues):
             return
         self.controller.go()
-        self.cue_list.set_playhead(self.controller.playhead_index)
+        new_idx = self.controller.playhead_index
+        self.cue_list.set_playhead(new_idx)
+        # Selectie en focus volgen de playhead zodat pijltjestoetsen en Spatie
+        # blijven werken zonder dat de gebruiker eerst een cue moet aanklikken.
+        if 0 <= new_idx < len(self.ws.cues):
+            self.cue_list.select_cue(self.ws.cues[new_idx].id)
+        self.cue_list.setFocus()
 
     def action_stop_all(self) -> None:
         self.controller.stop_all()
+        self.cue_list.setFocus()
 
     # ---- actions: help ----------------------------------------------------
 


### PR DESCRIPTION
## Summary
- **Selectie stuurt de playhead** — enkelklik / pijltje ↑↓ verplaatst de playhead zonder te vuren. Dubbelklik blijft playhead+GO.
- **`select_cue` fix** — `clearSelection` + `setSelected(True)` + `setCurrentItem` omdat in ExtendedSelection-mode `setCurrentItem` niet automatisch selecteert.
- **Focus-fix** — `action_go` selecteert + focust de cuelist op de nieuwe playhead-positie, `action_stop_all` zet focus ook terug, zodat Spatie/pijltjes blijven werken zonder klik na een GO.

## Test plan
- [x] pytest 17/17 groen
- [x] Enkelklik zet playhead (visueel bold nummer + transport-label update), geen GO
- [x] Spatie start cue, volgende Spatie start de volgende zonder klikken tussendoor
- [x] Pijltje ↑↓ navigeert playhead terwijl audio afspeelt
- [x] Dubbelklik doet nog steeds playhead+GO
- [x] Ctrl+↑↓ blijft cues reorderen

🤖 Generated with [Claude Code](https://claude.com/claude-code)