### PR TITLE
feat(video): VLC-based Video-cues (v0.6.0 MVP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build/
 !tests/**/*.livefire
 settings.json
 .claude/
+test_media/

--- a/livefire/cues/base.py
+++ b/livefire/cues/base.py
@@ -13,6 +13,7 @@ class CueType:
     omdat we ze direct in JSON opslaan."""
 
     AUDIO = "Audio"
+    VIDEO = "Video"
     GROUP = "Group"
     WAIT = "Wait"
     STOP = "Stop"
@@ -20,13 +21,11 @@ class CueType:
     MEMO = "Memo"
     START = "Start"
 
-    # Toekomstige types (nog niet geïmplementeerd in v0.3.0):
-    # VIDEO = "Video"   -> v0.6.0
-    # MIDI  = "MIDI"    -> v0.4.0
-    # OSC   = "OSC"     -> v0.4.0
+    # Toekomstige types (nog niet geïmplementeerd):
+    # MIDI  = "MIDI"    -> v0.4.x
     # DMX   = "DMX"     -> v0.5.0
 
-    ALL = [AUDIO, GROUP, WAIT, STOP, FADE, START, MEMO]
+    ALL = [AUDIO, VIDEO, GROUP, WAIT, STOP, FADE, START, MEMO]
 
 
 class ContinueMode:
@@ -70,6 +69,11 @@ class Cue:
     audio_end_offset: float = 0.0
     audio_fade_in: float = 0.0   # s, 0 = hard in
     audio_fade_out: float = 0.0  # s, 0 = hard out
+
+    # Video (v0.6.0 MVP)
+    video_output_screen: int = 0     # index in QGuiApplication.screens()
+    video_fade_in: float = 0.0       # s, 0 = hard in
+    video_fade_out: float = 0.0      # s, 0 = fade-to-black uit
 
     # Fade-target
     target_cue_id: str = ""    # voor Stop, Fade, Start

--- a/livefire/engines/__init__.py
+++ b/livefire/engines/__init__.py
@@ -1,5 +1,6 @@
 from .audio import AudioEngine
 from .osc import OscInputEngine
+from .video import VideoEngine
 from . import registry
 
-__all__ = ["AudioEngine", "OscInputEngine", "registry"]
+__all__ = ["AudioEngine", "OscInputEngine", "VideoEngine", "registry"]

--- a/livefire/engines/video.py
+++ b/livefire/engines/video.py
@@ -1,0 +1,282 @@
+"""Video-engine op basis van python-vlc (libVLC).
+
+Scope v0.6.0 MVP:
+- Eén VLC-player per spelende cue
+- Per-cue keuze van output-scherm (fullscreen op QScreen index)
+- Fade-in / fade-out via Qt window-opacity animation
+- Audio van de video via libVLC's eigen output (audio-device te kiezen
+  in Voorkeuren, separaat van de sounddevice audio-engine)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from PyQt6.QtCore import (
+    QObject, QPropertyAnimation, QEasingCurve, pyqtSignal, Qt, QTimer,
+)
+from PyQt6.QtGui import QGuiApplication
+from PyQt6.QtWidgets import QWidget
+
+from .registry import EngineStatus, register
+
+# Optionele dependency — engine werkt degraded zonder.
+try:
+    import vlc  # type: ignore[import-not-found]
+    _VLC_OK = True
+    _VLC_ERR = ""
+    _VLC_VERSION = ""
+    try:
+        v = vlc.libvlc_get_version()
+        _VLC_VERSION = v.decode() if isinstance(v, bytes) else str(v)
+    except Exception:
+        pass
+except Exception as e:
+    vlc = None  # type: ignore[assignment]
+    _VLC_OK = False
+    _VLC_ERR = str(e)
+    _VLC_VERSION = ""
+
+
+def list_screens() -> list[tuple[int, str]]:
+    """(index, label) voor elk beschikbaar scherm via QGuiApplication."""
+    out: list[tuple[int, str]] = []
+    for i, sc in enumerate(QGuiApplication.screens()):
+        geo = sc.geometry()
+        label = f"{i}: {sc.name()} ({geo.width()}×{geo.height()})"
+        out.append((i, label))
+    return out
+
+
+def list_audio_devices(instance: "vlc.Instance | None" = None) -> list[tuple[str, str]]:
+    """(device_id, naam) paren van VLC's audio-output van de huidige module.
+    Leeg als libVLC niet beschikbaar is."""
+    if not _VLC_OK:
+        return []
+    inst = instance or vlc.Instance()  # type: ignore[union-attr]
+    mp = inst.media_player_new()
+    out: list[tuple[str, str]] = []
+    try:
+        d = mp.audio_output_device_enum()
+        while d:
+            dev = d.contents
+            dev_id = dev.device.decode() if dev.device else ""
+            dev_name = dev.description.decode() if dev.description else dev_id
+            out.append((dev_id, dev_name))
+            d = dev.next
+    finally:
+        mp.release()
+    return out
+
+
+class VideoWindow(QWidget):
+    """Frameless fullscreen-widget waar libVLC in rendert. Qt beheert de
+    window-opacity zodat fade-in / fade-out via QPropertyAnimation kunnen."""
+
+    def __init__(self, screen_index: int = 0, parent=None):
+        super().__init__(parent, Qt.WindowType.FramelessWindowHint | Qt.WindowType.Tool)
+        self.setStyleSheet("background-color: black;")
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, False)
+        screens = QGuiApplication.screens()
+        if not screens:
+            self.setGeometry(0, 0, 800, 600)
+        else:
+            idx = max(0, min(screen_index, len(screens) - 1))
+            self.setGeometry(screens[idx].geometry())
+        self.setWindowOpacity(0.0)
+
+    def hwnd_id(self) -> int:
+        """Native window-handle om aan libVLC te geven (Windows HWND)."""
+        return int(self.winId())
+
+
+class VideoEngine(QObject):
+    """Beheert één VLC-Instance en een dict van playing cue → (player, window)."""
+
+    cue_finished = pyqtSignal(str)   # cue_id — eindigt van nature
+
+    def __init__(self, parent: QObject | None = None):
+        super().__init__(parent)
+        self._instance: "vlc.Instance | None" = None
+        if _VLC_OK:
+            try:
+                self._instance = vlc.Instance("--no-video-title-show", "--quiet")  # type: ignore[union-attr]
+            except Exception as e:
+                self._instance = None
+                # Blijf leven in degraded mode.
+                global _VLC_ERR
+                _VLC_ERR = str(e)
+        self._playing: dict[str, dict] = {}   # cue_id → {"player", "window", "fade_anim"}
+        self._audio_device: str = ""
+
+    @property
+    def available(self) -> bool:
+        return _VLC_OK and self._instance is not None
+
+    def set_audio_device(self, device_id: str) -> None:
+        """Sla het gekozen VLC audio-device op; wordt toegepast op nieuwe players."""
+        self._audio_device = device_id or ""
+
+    def play_file(
+        self,
+        cue_id: str,
+        file_path: str,
+        screen_index: int = 0,
+        fade_in: float = 0.0,
+        fade_out: float = 0.0,
+    ) -> tuple[bool, str]:
+        if not self.available:
+            return False, _VLC_ERR or "libVLC niet beschikbaar"
+        path = Path(file_path)
+        if not path.is_file():
+            return False, f"Bestand niet gevonden: {path}"
+        # Bestaande player voor deze cue? Stop eerst.
+        if cue_id in self._playing:
+            self.stop_cue(cue_id, fade_out=0.0)
+
+        window = VideoWindow(screen_index=screen_index)
+        window.showFullScreen()
+        QGuiApplication.processEvents()
+
+        player = self._instance.media_player_new()  # type: ignore[union-attr]
+        player.set_hwnd(window.hwnd_id())
+        if self._audio_device:
+            try:
+                player.audio_output_device_set(None, self._audio_device)
+            except Exception:
+                pass
+
+        media = self._instance.media_new(str(path))  # type: ignore[union-attr]
+        player.set_media(media)
+        player.play()
+
+        # Fade-in via Qt window-opacity animation.
+        if fade_in > 0:
+            anim = QPropertyAnimation(window, b"windowOpacity")
+            anim.setDuration(int(fade_in * 1000))
+            anim.setStartValue(0.0)
+            anim.setEndValue(1.0)
+            anim.setEasingCurve(QEasingCurve.Type.InOutQuad)
+            anim.start()
+        else:
+            window.setWindowOpacity(1.0)
+            anim = None
+
+        self._playing[cue_id] = {
+            "player": player,
+            "window": window,
+            "media": media,
+            "fade_anim": anim,
+            "fade_out_s": fade_out,
+        }
+
+        # Detecteer natuurlijk einde via VLC event.
+        em = player.event_manager()
+        em.event_attach(
+            vlc.EventType.MediaPlayerEndReached,  # type: ignore[union-attr]
+            lambda _e, cid=cue_id: QTimer.singleShot(0, lambda: self._on_end_reached(cid)),
+        )
+        return True, ""
+
+    def stop_cue(self, cue_id: str, fade_out: float = 0.0) -> None:
+        entry = self._playing.get(cue_id)
+        if entry is None:
+            return
+        window = entry["window"]
+        player = entry["player"]
+        duration_s = fade_out if fade_out > 0 else entry.get("fade_out_s", 0.0)
+        if duration_s > 0:
+            anim = QPropertyAnimation(window, b"windowOpacity")
+            anim.setDuration(int(duration_s * 1000))
+            anim.setStartValue(window.windowOpacity())
+            anim.setEndValue(0.0)
+            anim.setEasingCurve(QEasingCurve.Type.InOutQuad)
+            anim.finished.connect(lambda cid=cue_id: self._hard_stop(cid))
+            entry["fade_anim"] = anim
+            anim.start()
+        else:
+            self._hard_stop(cue_id)
+
+    def stop_all(self) -> None:
+        for cid in list(self._playing.keys()):
+            self._hard_stop(cid)
+
+    def is_playing(self, cue_id: str) -> bool:
+        return cue_id in self._playing
+
+    def get_remaining(self, cue_id: str) -> float | None:
+        entry = self._playing.get(cue_id)
+        if entry is None:
+            return None
+        player = entry["player"]
+        try:
+            length_ms = player.get_length()
+            pos_ms = player.get_time()
+        except Exception:
+            return None
+        if length_ms <= 0:
+            return None
+        return max(0.0, (length_ms - pos_ms) / 1000.0)
+
+    def shutdown(self) -> None:
+        self.stop_all()
+        if self._instance is not None:
+            try:
+                self._instance.release()
+            except Exception:
+                pass
+        self._instance = None
+
+    # ---- intern ------------------------------------------------------------
+
+    def _hard_stop(self, cue_id: str) -> None:
+        entry = self._playing.pop(cue_id, None)
+        if entry is None:
+            return
+        try:
+            entry["player"].stop()
+            entry["player"].release()
+        except Exception:
+            pass
+        try:
+            entry["window"].close()
+            entry["window"].deleteLater()
+        except Exception:
+            pass
+
+    def _on_end_reached(self, cue_id: str) -> None:
+        """Draait op UI-thread via QTimer.singleShot. Signaleer aan de
+        controller dat deze cue natuurlijk klaar is (voor AUTO_FOLLOW)."""
+        if cue_id in self._playing:
+            # Laat de controller beslissen; die zal stop_cue met eventueel
+            # fade-out aanroepen. Wij merken 'm hier alleen voor de signaal.
+            self.cue_finished.emit(cue_id)
+
+
+# ---- status-registratie ----------------------------------------------------
+
+def register_status(engine: VideoEngine | None = None) -> None:
+    if not _VLC_OK:
+        register(EngineStatus(
+            name="Video (libVLC)",
+            available=False,
+            detail=f"python-vlc niet geladen: {_VLC_ERR}",
+            short="video",
+        ))
+        return
+    if engine is None or not engine.available:
+        register(EngineStatus(
+            name="Video (libVLC)",
+            available=False,
+            detail=_VLC_ERR or "libVLC-instance niet opgestart",
+            short="video",
+        ))
+        return
+    detail = f"libVLC {_VLC_VERSION}" if _VLC_VERSION else "libVLC OK"
+    register(EngineStatus(
+        name="Video (libVLC)",
+        available=True,
+        detail=detail,
+        short="video",
+    ))

--- a/livefire/playback/controller.py
+++ b/livefire/playback/controller.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from PyQt6.QtCore import QObject, QTimer, pyqtSignal
 
 from ..cues import Cue, CueType, ContinueMode
-from ..engines import AudioEngine, OscInputEngine
+from ..engines import AudioEngine, OscInputEngine, VideoEngine
 from ..workspace import Workspace
 
 
@@ -44,6 +44,7 @@ class PlaybackController(QObject):
         parent: QObject | None = None,
         audio: AudioEngine | None = None,
         osc: OscInputEngine | None = None,
+        video: VideoEngine | None = None,
     ):
         super().__init__(parent)
         self.workspace = workspace
@@ -52,6 +53,8 @@ class PlaybackController(QObject):
 
         self.osc = osc if osc is not None else OscInputEngine(self)
         self.osc.message_received.connect(self._on_osc_message)
+
+        self.video = video if video is not None else VideoEngine(self)
 
         self._running: dict[str, _Running] = {}
         self._playhead_index: int = 0
@@ -73,6 +76,7 @@ class PlaybackController(QObject):
         self.stop_all()
         self.audio.stop()
         self.osc.stop()
+        self.video.shutdown()
 
     # ---- transport ---------------------------------------------------------
 
@@ -151,11 +155,13 @@ class PlaybackController(QObject):
         for cid in ids:
             self._stop_running(cid, finished=False)
         self.audio.stop_all()
+        self.video.stop_all()
 
     def stop_cue(self, cue_id: str) -> None:
         if cue_id in self._running:
             self._stop_running(cue_id, finished=False)
         self.audio.stop_cue(cue_id)
+        self.video.stop_cue(cue_id)
 
     # ---- cue-specifieke start-logica --------------------------------------
 
@@ -190,6 +196,19 @@ class PlaybackController(QObject):
             else:
                 r.action_duration = cue.duration if cue.duration > 0 else 0.0
                 # 0 = laten lopen tot bestand op is (detecteren via audio.is_playing)
+
+        elif t == CueType.VIDEO:
+            ok, _err = self.video.play_file(
+                cue_id=cue.id,
+                file_path=cue.file_path,
+                screen_index=cue.video_output_screen,
+                fade_in=cue.video_fade_in,
+                fade_out=cue.video_fade_out,
+            )
+            if not ok:
+                r.action_duration = 0.0
+            else:
+                r.action_duration = cue.duration if cue.duration > 0 else 0.0
 
         elif t == CueType.WAIT:
             r.action_duration = cue.wait_duration
@@ -294,19 +313,42 @@ class PlaybackController(QObject):
                         # Wacht tot fade-out klaar is voor we post_wait ingaan.
                         if not self.audio.is_playing(r.cue.id):
                             finished = True
+                elif r.cue.cue_type == CueType.VIDEO:
+                    # Zelfde patroon als audio: duration > 0 of natuurlijk einde,
+                    # daarna fade-out (zit al in video-engine via stored fade_out_s).
+                    main_done = False
+                    if r.action_duration > 0:
+                        if elapsed_phase >= r.action_duration:
+                            main_done = True
+                    else:
+                        if not self.video.is_playing(r.cue.id):
+                            main_done = True
+
+                    if main_done and not r.stop_triggered:
+                        self.video.stop_cue(r.cue.id, fade_out=r.cue.video_fade_out)
+                        r.stop_triggered = True
+                        if r.cue.continue_mode == ContinueMode.AUTO_FOLLOW:
+                            to_advance.append(cid)
+                        if r.cue.video_fade_out <= 0:
+                            finished = True
+                    elif r.stop_triggered:
+                        if not self.video.is_playing(r.cue.id):
+                            finished = True
                 else:
                     if elapsed_phase >= r.action_duration:
                         finished = True
-                        # Niet-audio: AUTO_FOLLOW triggert hier.
+                        # Niet-audio/video: AUTO_FOLLOW triggert hier.
                         if r.cue.continue_mode == ContinueMode.AUTO_FOLLOW:
                             to_advance.append(cid)
 
                 if finished:
                     r.phase = "post_wait"
                     r.phase_started_at = now
-                    # Zorg dat er niets blijft hangen in de mixer.
+                    # Zorg dat er niets blijft hangen.
                     if r.cue.cue_type == CueType.AUDIO:
                         self.audio.stop_cue(r.cue.id)
+                    elif r.cue.cue_type == CueType.VIDEO:
+                        self.video.stop_cue(r.cue.id)
 
             elif r.phase == "post_wait":
                 if elapsed_phase >= r.cue.post_wait:

--- a/livefire/ui/cuetoolbar.py
+++ b/livefire/ui/cuetoolbar.py
@@ -17,6 +17,7 @@ from ..cues import CueType
 # de knoppen meteen herkenbaar zijn.
 _CUE_TYPE_ACCENTS = {
     CueType.AUDIO:  "#2980b9",  # blauw
+    CueType.VIDEO:  "#16a085",  # teal
     CueType.FADE:   "#c9a227",  # geel
     CueType.WAIT:   "#606060",  # grijs
     CueType.STOP:   "#c0392b",  # rood
@@ -26,12 +27,13 @@ _CUE_TYPE_ACCENTS = {
 }
 
 _CUE_TYPE_ORDER = [
-    CueType.AUDIO, CueType.FADE, CueType.WAIT, CueType.STOP,
+    CueType.AUDIO, CueType.VIDEO, CueType.FADE, CueType.WAIT, CueType.STOP,
     CueType.START, CueType.GROUP, CueType.MEMO,
 ]
 
 _CUE_TYPE_TIPS = {
     CueType.AUDIO: "Nieuwe Audio-cue (Ctrl+1)",
+    CueType.VIDEO: "Nieuwe Video-cue (Ctrl+8)",
     CueType.FADE:  "Nieuwe Fade-cue (Ctrl+2)",
     CueType.WAIT:  "Nieuwe Wait-cue (Ctrl+3)",
     CueType.STOP:  "Nieuwe Stop-cue (Ctrl+4)",

--- a/livefire/ui/dialogs/preferences.py
+++ b/livefire/ui/dialogs/preferences.py
@@ -16,6 +16,7 @@ from ...engines.audio import (
 from ...engines.audio import register_status as register_audio_status
 from ...engines.osc import OscInputEngine, DEFAULT_OSC_PORT
 from ...engines.osc import register_status as register_osc_status
+from ...engines.video import VideoEngine, list_audio_devices as list_vlc_audio_devices
 
 
 SUPPORTED_SAMPLE_RATES = [44100, 48000, 96000]
@@ -29,11 +30,13 @@ class PreferencesDialog(QDialog):
         self,
         engine: AudioEngine,
         osc: OscInputEngine | None = None,
+        video: VideoEngine | None = None,
         parent=None,
     ):
         super().__init__(parent)
         self.engine = engine
         self.osc = osc
+        self.video = video
         self.setWindowTitle("Voorkeuren")
         self.setMinimumWidth(440)
 
@@ -88,6 +91,20 @@ class PreferencesDialog(QDialog):
         osc_form.addRow("UDP-poort", self.sp_osc_port)
         root.addWidget(grp_osc)
 
+        # ---- Video --------------------------------------------------------
+        grp_video = QGroupBox("Video (libVLC)")
+        video_form = QFormLayout(grp_video)
+        self.cb_video_audio = QComboBox()
+        self.cb_video_audio.setToolTip(
+            "Output-device voor de audio van video-cues. libVLC gebruikt z'n "
+            "eigen device-lijst, los van de sounddevice audio-engine."
+        )
+        self.cb_video_audio.addItem("Systeem-default", "")
+        for dev_id, dev_name in list_vlc_audio_devices():
+            self.cb_video_audio.addItem(dev_name, dev_id)
+        video_form.addRow("Audio-device", self.cb_video_audio)
+        root.addWidget(grp_video)
+
         # Waarden uit QSettings (of huidige engine-config als fallback).
         self._load_from_settings()
 
@@ -134,6 +151,10 @@ class PreferencesDialog(QDialog):
         self.sp_osc_port.setValue(
             s.value("osc/port", DEFAULT_OSC_PORT, type=int)
         )
+
+        video_dev = s.value("video/audio_device", "", type=str)
+        v_idx = self.cb_video_audio.findData(video_dev)
+        self.cb_video_audio.setCurrentIndex(v_idx if v_idx >= 0 else 0)
 
     # ---- apply -------------------------------------------------------------
 
@@ -190,5 +211,11 @@ class PreferencesDialog(QDialog):
             s.setValue("osc/enabled", bool(osc_enabled))
             s.setValue("osc/port", osc_port)
             register_osc_status(self.osc)
+
+        # Video audio-device toepassen (neemt effect vanaf volgende Video-cue)
+        video_dev = self.cb_video_audio.currentData() or ""
+        s.setValue("video/audio_device", video_dev)
+        if self.video is not None:
+            self.video.set_audio_device(video_dev)
 
         self.accept()

--- a/livefire/ui/inspector.py
+++ b/livefire/ui/inspector.py
@@ -16,6 +16,7 @@ from PyQt6.QtWidgets import (
 )
 
 from ..cues import Cue, CueType, ContinueMode
+from ..engines.video import list_screens
 from ..workspace import Workspace
 from .style import CUE_COLORS
 
@@ -171,6 +172,35 @@ class InspectorWidget(QWidget):
         al.addRow("Fade-out (s)", self.sp_fade_out)
         lay.addWidget(self.grp_audio)
 
+        # ---- Video ---------------------------------------------------------
+        self.grp_video = QGroupBox("Video")
+        vl = QFormLayout(self.grp_video)
+        video_path_row = QHBoxLayout()
+        self.ed_video_path = QLineEdit()
+        self.ed_video_path.setToolTip("Pad naar het video-bestand.")
+        self.btn_browse_video = QPushButton("Bladeren…")
+        self.btn_browse_video.setToolTip("Kies een videobestand.")
+        self.btn_browse_video.clicked.connect(self._browse_video)
+        video_path_row.addWidget(self.ed_video_path)
+        video_path_row.addWidget(self.btn_browse_video)
+        vpc = QWidget()
+        vpc.setLayout(video_path_row)
+        vl.addRow("Bestand", vpc)
+        self.cb_video_screen = QComboBox()
+        self.cb_video_screen.setToolTip(
+            "Monitor waarop deze cue fullscreen wordt weergegeven."
+        )
+        for idx, label in list_screens():
+            self.cb_video_screen.addItem(label, idx)
+        vl.addRow("Output-scherm", self.cb_video_screen)
+        self.sp_video_fade_in = self._spin_seconds(max_val=600.0)
+        self.sp_video_fade_in.setToolTip("Fade-in vanuit zwart.")
+        self.sp_video_fade_out = self._spin_seconds(max_val=600.0)
+        self.sp_video_fade_out.setToolTip("Fade-to-black aan het einde van de cue.")
+        vl.addRow("Fade-in (s)", self.sp_video_fade_in)
+        vl.addRow("Fade-out (s)", self.sp_video_fade_out)
+        lay.addWidget(self.grp_video)
+
         # ---- Wait ----------------------------------------------------------
         self.grp_wait = QGroupBox("Wait")
         wl = QFormLayout(self.grp_wait)
@@ -256,23 +286,29 @@ class InspectorWidget(QWidget):
             self.cb_target:      ("target_cue_id",      lambda: self.cb_target.currentData() or ""),
             self.ed_trigger_osc: ("trigger_osc",        lambda: self.ed_trigger_osc.text().strip()),
             self.ed_notes:       ("notes",              lambda: self.ed_notes.toPlainText()),
+            self.ed_video_path:   ("file_path",           lambda: self.ed_video_path.text()),
+            self.cb_video_screen: ("video_output_screen", lambda: self.cb_video_screen.currentData()),
+            self.sp_video_fade_in:  ("video_fade_in",     lambda: self.sp_video_fade_in.value()),
+            self.sp_video_fade_out: ("video_fade_out",    lambda: self.sp_video_fade_out.value()),
         }
 
         for w in (self.ed_number, self.ed_name, self.ed_path, self.ed_notes,
-                  self.ed_trigger_osc):
+                  self.ed_trigger_osc, self.ed_video_path):
             if isinstance(w, QPlainTextEdit):
                 w.textChanged.connect(self._on_any_change)
             else:
                 w.textChanged.connect(self._on_any_change)
         for w in (self.sp_pre, self.sp_dur, self.sp_post, self.sp_volume,
                   self.sp_start, self.sp_end, self.sp_fade_in, self.sp_fade_out,
-                  self.sp_wait, self.sp_fade_target):
+                  self.sp_wait, self.sp_fade_target,
+                  self.sp_video_fade_in, self.sp_video_fade_out):
             w.valueChanged.connect(self._on_any_change)
         self.sp_loops.valueChanged.connect(self._on_any_change)
         self.cb_type.currentTextChanged.connect(self._on_type_change)
         self.cb_continue.currentIndexChanged.connect(self._on_any_change)
         self.cb_target.currentIndexChanged.connect(self._on_any_change)
         self.cb_color.currentIndexChanged.connect(self._on_any_change)
+        self.cb_video_screen.currentIndexChanged.connect(self._on_any_change)
         self.chk_fade_stops.toggled.connect(self._on_any_change)
 
         self.set_cues([])
@@ -324,6 +360,7 @@ class InspectorWidget(QWidget):
         if not self.cues:
             self.header.setText("Geen cue geselecteerd")
             self.grp_audio.setVisible(False)
+            self.grp_video.setVisible(False)
             self.grp_wait.setVisible(False)
             self.grp_target.setVisible(False)
             self.content.setEnabled(False)
@@ -366,6 +403,14 @@ class InspectorWidget(QWidget):
         self.ed_trigger_osc.setText(cue.trigger_osc if not multi else "")
         self.ed_notes.setPlainText(cue.notes if not multi else "")
 
+        # Video-velden
+        self.ed_video_path.setText(cue.file_path if not multi else "")
+        idx_screen = self.cb_video_screen.findData(cue.video_output_screen)
+        if idx_screen >= 0:
+            self.cb_video_screen.setCurrentIndex(idx_screen)
+        self.sp_video_fade_in.setValue(cue.video_fade_in)
+        self.sp_video_fade_out.setValue(cue.video_fade_out)
+
         self.refresh_targets()
         idx = self.cb_target.findData(cue.target_cue_id)
         if idx >= 0:
@@ -376,13 +421,14 @@ class InspectorWidget(QWidget):
         # Per-cue velden uitschakelen bij multi-select.
         for w in (self.ed_number, self.ed_name, self.ed_path, self.ed_notes,
                   self.ed_trigger_osc, self.cb_target, self.btn_browse,
-                  self.btn_learn_osc):
+                  self.btn_learn_osc, self.ed_video_path, self.btn_browse_video):
             w.setEnabled(not multi)
 
         self._updating = False
 
     def _update_visibility(self, cue_type: str) -> None:
         self.grp_audio.setVisible(cue_type == CueType.AUDIO)
+        self.grp_video.setVisible(cue_type == CueType.VIDEO)
         self.grp_wait.setVisible(cue_type == CueType.WAIT)
         self.grp_target.setVisible(cue_type in (CueType.STOP, CueType.FADE, CueType.START))
 
@@ -427,6 +473,25 @@ class InspectorWidget(QWidget):
         if idx < 0:
             idx = 0  # "Geen"
         self.cb_color.setCurrentIndex(idx)
+
+    def _browse_video(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Kies video-bestand", "",
+            "Video (*.mp4 *.mov *.avi *.mkv *.webm *.m4v);;Alle bestanden (*)",
+        )
+        if path:
+            # Zelfde auto-fill-naam logica als _browse_file, maar voor video.
+            old_path = self.ed_video_path.text().strip()
+            name = self.ed_name.text().strip()
+            auto_default = bool(re.match(
+                r"^(?:" + "|".join(CueType.ALL) + r") \d+$", name
+            ))
+            from_old_file = bool(old_path) and name == Path(old_path).stem
+            should_fill = not name or auto_default or from_old_file
+
+            self.ed_video_path.setText(path)
+            if should_fill and self.cue is not None and not len(self.cues) > 1:
+                self.ed_name.setText(Path(path).stem)
 
     def _browse_file(self) -> None:
         path, _ = QFileDialog.getOpenFileName(

--- a/livefire/ui/mainwindow.py
+++ b/livefire/ui/mainwindow.py
@@ -22,6 +22,7 @@ from ..engines.audio import (
     find_device_index_by_name,
 )
 from ..engines.osc import register_status as register_osc_status
+from ..engines.video import register_status as register_video_status
 
 from .cuelist import CueListWidget
 from .cuetoolbar import CueToolbar
@@ -55,6 +56,9 @@ class MainWindow(QMainWindow):
         # Engine status registreren
         register_audio_status(self.controller.audio)
         register_osc_status(self.controller.osc)
+        register_video_status(self.controller.video)
+        # VLC-audio-device uit QSettings toepassen
+        self._apply_video_audio_device_from_settings()
 
         # UI
         self._build_ui()
@@ -148,6 +152,8 @@ class MainWindow(QMainWindow):
         m_cue.setToolTipsVisible(True)
         self._add_action(m_cue, "Nieuwe Audio-cue", lambda: self.action_new_cue(CueType.AUDIO), QKeySequence("Ctrl+1"),
                          tip="Speelt een audio-bestand af met volume, loops en fades")
+        self._add_action(m_cue, "Nieuwe Video-cue", lambda: self.action_new_cue(CueType.VIDEO), QKeySequence("Ctrl+8"),
+                         tip="Speelt een video-bestand fullscreen af op het gekozen scherm (libVLC)")
         self._add_action(m_cue, "Nieuwe Fade-cue", lambda: self.action_new_cue(CueType.FADE), QKeySequence("Ctrl+2"),
                          tip="Verandert het volume van een andere (lopende) audio-cue over tijd")
         self._add_action(m_cue, "Nieuwe Wait-cue", lambda: self.action_new_cue(CueType.WAIT), QKeySequence("Ctrl+3"),
@@ -323,7 +329,10 @@ class MainWindow(QMainWindow):
         dlg.exec()
 
     def action_preferences(self) -> None:
-        dlg = PreferencesDialog(self.controller.audio, self.controller.osc, self)
+        dlg = PreferencesDialog(
+            self.controller.audio, self.controller.osc,
+            self.controller.video, self,
+        )
         if dlg.exec():
             self._refresh_statusbar()
 
@@ -339,6 +348,12 @@ class MainWindow(QMainWindow):
         sr = s.value("audio/samplerate", DEFAULT_SAMPLE_RATE, type=int)
         device = find_device_index_by_name(device_name) if device_name else None
         return AudioEngine(sample_rate=sr, device=device)
+
+    def _apply_video_audio_device_from_settings(self) -> None:
+        s = QSettings()
+        dev = s.value("video/audio_device", "", type=str)
+        if dev:
+            self.controller.video.set_audio_device(dev)
 
     def _start_osc_from_settings(self) -> None:
         s = QSettings()
@@ -384,14 +399,15 @@ class MainWindow(QMainWindow):
             if ext in self._AUDIO_EXTS:
                 cue = Cue(cue_type=CueType.AUDIO, cue_number=str(n),
                           name=path.stem, file_path=str(path))
-            elif ext in self._VIDEO_EXTS or ext in self._IMAGE_EXTS:
-                kind = "Video" if ext in self._VIDEO_EXTS else "Afbeelding"
+            elif ext in self._VIDEO_EXTS:
+                cue = Cue(cue_type=CueType.VIDEO, cue_number=str(n),
+                          name=path.stem, file_path=str(path))
+            elif ext in self._IMAGE_EXTS:
                 cue = Cue(
                     cue_type=CueType.MEMO, cue_number=str(n), name=path.stem,
-                    notes=(f"[{kind}-placeholder] {path}\n\n"
-                           "Cue-type voor dit bestandstype is nog niet "
-                           "geïmplementeerd — bewaar als Memo totdat v0.6.0 "
-                           "Video-cues introduceert."),
+                    notes=(f"[Afbeelding-placeholder] {path}\n\n"
+                           "Image-cue-type is nog niet geïmplementeerd — "
+                           "bewaar als Memo."),
                 )
             else:
                 continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,10 @@ python-osc>=1.8
 # mido>=1.3
 # python-rtmidi>=1.5
 
+# Video
+python-vlc>=3.0
+
 # Optioneel nog uit te werken in komende versies:
 # pyartnet>=0.8      # DMX Art-Net (v0.5)
 # sacn>=1.9          # sACN E1.31 (v0.5)
-# python-vlc>=3.0    # Video via libVLC (v0.6)
 # cyndilib>=0.0.8    # NDI-out (v0.6)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -30,6 +30,11 @@ def test_roundtrip_preserves_all_cue_types(tmp_path: Path):
                    target_cue_id=target,
                    continue_mode=ContinueMode.AUTO_CONTINUE,
                    trigger_osc="/livefire/go/start"))
+    ws.add_cue(Cue(cue_type=CueType.VIDEO, name="movie",
+                   file_path="C:/tmp/movie.mp4",
+                   video_output_screen=1,
+                   video_fade_in=0.5,
+                   video_fade_out=1.5))
 
     p = tmp_path / "test.livefire"
     ws.save(p)
@@ -48,6 +53,9 @@ def test_roundtrip_preserves_all_cue_types(tmp_path: Path):
         assert orig.audio_fade_in == got.audio_fade_in
         assert orig.audio_fade_out == got.audio_fade_out
         assert orig.trigger_osc == got.trigger_osc
+        assert orig.video_output_screen == got.video_output_screen
+        assert orig.video_fade_in == got.video_fade_in
+        assert orig.video_fade_out == got.video_fade_out
 
 
 def test_save_writes_current_format_version(tmp_path: Path):


### PR DESCRIPTION
## Summary
Nieuwe cue-type **VIDEO** met libVLC als engine (scope B uit de roadmap):
- Fullscreen op een per-cue gekozen output-scherm (QGuiApplication.screens())
- Fade-in vanuit zwart + fade-to-black (Qt window-opacity + QPropertyAnimation)
- Audio direct via VLC's eigen output; device instelbaar in Voorkeuren (VLC's eigen enumeratie, los van sounddevice)
- Drag-drop van .mp4/.mov/.avi/.mkv/.webm maakt Video-cues (voorheen Memo-placeholder)

## Nieuwe files
- `livefire/engines/video.py` — `VideoEngine` + `VideoWindow`

## Gewijzigde files
- `Cue`: VIDEO in CueType.ALL + velden `video_output_screen`/`video_fade_in`/`video_fade_out`
- `PlaybackController`: VIDEO-tak met hetzelfde stop_triggered-patroon als AUDIO
- `Inspector`: Video-groep met bladeren, scherm-dropdown, fades
- `CueToolbar` + Cue-menu (Ctrl+8) + teal-swatch
- `PreferencesDialog`: Video-sectie met audio-device dropdown
- `MainWindow`: wires video engine + applies QSettings + drag-drop routeert naar VIDEO
- `engine-status registry`: toont libVLC versie

## Test plan
- [x] pytest 17/17 groen (incl. video-fields in workspace-roundtrip)
- [x] Engine-status toont "libVLC 3.0.23"
- [x] Visueel bevestigd met 3 test-MP4s: fullscreen, fade-in/out, scherm-keuze, audio werkt

## Out of scope (latere v0.6.x)
- NDI-out via cyndilib
- Multi-screen routing (één video op meerdere schermen tegelijk)
- Opacity/position/size controls (video-matrix in v0.6.x)
- Audio-routing via sounddevice master-mixer

🤖 Generated with [Claude Code](https://claude.com/claude-code)