### PR TITLE
feat(video): in/uit-punt trim met live preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Alle noemenswaardige wijzigingen aan dit project. Format volgens
 ## [Unreleased]
 
 ### Toegevoegd
+- **Trim** (in/uit-punt) op Video-cues. De inspector toont een
+  preview-widget met VLC-thumbnail en sleepbare tijdlijn-markers; daarnaast
+  spinboxen voor numerieke invoer. Beide paden syncen bidirectioneel en
+  scrubben de preview live mee. Trim wordt aan libVLC doorgegeven via
+  `:start-time` / `:stop-time`; de Duur-kolom in de cuelist en de
+  countdown respecteren het getrimde eind. Workspace bewaart
+  `video_start_offset`, `video_end_offset` en een gecachte
+  `video_file_duration`.
 - **OSC-input** voor cue-triggering vanaf Companion / Stream Deck / externe
   consoles. Elke cue krijgt een optioneel `trigger_osc` veld (bv.
   `/livefire/go/intro`); inkomende OSC-messages met dezelfde address vuren
@@ -33,6 +41,13 @@ Alle noemenswaardige wijzigingen aan dit project. Format volgens
 - Tests voor de engine-configuratie-API in `tests/test_audio_engine.py`.
 
 ### Gewijzigd
+- Spinbox-pijltjes (up/down) weer zichtbaar in het dark-theme via
+  expliciet gegenereerde arrow-pixmaps; in Qt-stylesheet-mode tekent Qt
+  geen native glyph meer. `STYLESHEET` is hierdoor een
+  `build_stylesheet()`-functie geworden (moet ná QApplication() draaien).
+- Inspector-edits triggeren een targeted refresh van de cuelist-rij in
+  plaats van een full clear/rebuild, zodat keyboard-focus op spinboxen
+  niet wegspringt tijdens typen.
 - Inspector-kleurveld is nu een dropdown met preset cue-kleuren (QLab-stijl)
   inclusief kleur-swatches. Niet-preset hex-waarden uit oudere workspaces
   blijven bewaard als "Aangepast".

--- a/livefire/__main__.py
+++ b/livefire/__main__.py
@@ -7,7 +7,7 @@ import sys
 from PyQt6.QtWidgets import QApplication
 
 from . import APP_NAME, SETTINGS_ORG, SETTINGS_APP
-from .ui import MainWindow, STYLESHEET
+from .ui import MainWindow, build_stylesheet
 
 
 def main() -> int:
@@ -15,7 +15,7 @@ def main() -> int:
     app.setOrganizationName(SETTINGS_ORG)
     app.setApplicationName(SETTINGS_APP)
     app.setApplicationDisplayName(APP_NAME)
-    app.setStyleSheet(STYLESHEET)
+    app.setStyleSheet(build_stylesheet())
 
     w = MainWindow()
     w.show()

--- a/livefire/cues/base.py
+++ b/livefire/cues/base.py
@@ -74,6 +74,9 @@ class Cue:
     video_output_screen: int = 0     # index in QGuiApplication.screens()
     video_fade_in: float = 0.0       # s, 0 = hard in
     video_fade_out: float = 0.0      # s, 0 = fade-to-black uit
+    video_start_offset: float = 0.0  # in-punt in seconden (0 = vanaf begin)
+    video_end_offset: float = 0.0    # uit-punt in seconden (0 = tot einde)
+    video_file_duration: float = 0.0 # cache van file-duur; auto-gevuld door preview
 
     # Fade-target
     target_cue_id: str = ""    # voor Stop, Fade, Start

--- a/livefire/engines/video.py
+++ b/livefire/engines/video.py
@@ -125,6 +125,8 @@ class VideoEngine(QObject):
         screen_index: int = 0,
         fade_in: float = 0.0,
         fade_out: float = 0.0,
+        start_offset: float = 0.0,
+        end_offset: float = 0.0,
     ) -> tuple[bool, str]:
         if not self.available:
             return False, _VLC_ERR or "libVLC niet beschikbaar"
@@ -147,7 +149,12 @@ class VideoEngine(QObject):
             except Exception:
                 pass
 
+        # In/uit-punt via media-opties. libVLC snapt :start-time / :stop-time.
         media = self._instance.media_new(str(path))  # type: ignore[union-attr]
+        if start_offset > 0:
+            media.add_option(f":start-time={start_offset:.3f}")
+        if end_offset > 0:
+            media.add_option(f":stop-time={end_offset:.3f}")
         player.set_media(media)
         player.play()
 
@@ -169,6 +176,7 @@ class VideoEngine(QObject):
             "media": media,
             "fade_anim": anim,
             "fade_out_s": fade_out,
+            "stop_ms": int(end_offset * 1000) if end_offset > 0 else 0,
         }
 
         # Detecteer natuurlijk einde via VLC event.
@@ -203,7 +211,23 @@ class VideoEngine(QObject):
             self._hard_stop(cid)
 
     def is_playing(self, cue_id: str) -> bool:
-        return cue_id in self._playing
+        """True zolang VLC actief rendert. False zodra de player in
+        Ended/Stopped/Error-state komt — zo detecteert de controller
+        natuurlijk einde (voor AUTO_FOLLOW en fade-out-trigger)."""
+        entry = self._playing.get(cue_id)
+        if entry is None:
+            return False
+        if not _VLC_OK:
+            return True
+        try:
+            state = entry["player"].get_state()
+        except Exception:
+            return True
+        return state not in (
+            vlc.State.Ended,    # type: ignore[union-attr]
+            vlc.State.Stopped,  # type: ignore[union-attr]
+            vlc.State.Error,    # type: ignore[union-attr]
+        )
 
     def get_remaining(self, cue_id: str) -> float | None:
         entry = self._playing.get(cue_id)
@@ -217,7 +241,11 @@ class VideoEngine(QObject):
             return None
         if length_ms <= 0:
             return None
-        return max(0.0, (length_ms - pos_ms) / 1000.0)
+        # Respecteer :stop-time: bij een getrimd uit-punt moet de countdown
+        # daarvandaan tellen, niet vanaf de file-lengte.
+        stop_ms = entry.get("stop_ms") or 0
+        effective_end_ms = stop_ms if 0 < stop_ms <= length_ms else length_ms
+        return max(0.0, (effective_end_ms - pos_ms) / 1000.0)
 
     def shutdown(self) -> None:
         self.stop_all()

--- a/livefire/playback/controller.py
+++ b/livefire/playback/controller.py
@@ -204,6 +204,8 @@ class PlaybackController(QObject):
                 screen_index=cue.video_output_screen,
                 fade_in=cue.video_fade_in,
                 fade_out=cue.video_fade_out,
+                start_offset=cue.video_start_offset,
+                end_offset=cue.video_end_offset,
             )
             if not ok:
                 r.action_duration = 0.0

--- a/livefire/ui/__init__.py
+++ b/livefire/ui/__init__.py
@@ -1,4 +1,4 @@
 from .mainwindow import MainWindow
-from .style import STYLESHEET
+from .style import build_stylesheet
 
-__all__ = ["MainWindow", "STYLESHEET"]
+__all__ = ["MainWindow", "build_stylesheet"]

--- a/livefire/ui/cuelist.py
+++ b/livefire/ui/cuelist.py
@@ -118,13 +118,25 @@ class CueListWidget(QTreeWidget):
         self._apply_playhead_style()
 
     def _make_item(self, cue: Cue, index: int) -> QTreeWidgetItem:
+        if cue.cue_type == CueType.VIDEO:
+            # Trim bepaalt effectieve duur:
+            # (end - start) als end > 0, anders (file_duration - start) als de
+            # preview 'm gecachet heeft, anders user-set cue.duration.
+            if cue.video_end_offset > 0:
+                dur_value = max(0.0, cue.video_end_offset - cue.video_start_offset)
+            elif cue.video_file_duration > 0:
+                dur_value = max(0.0, cue.video_file_duration - cue.video_start_offset)
+            else:
+                dur_value = cue.duration
+        elif cue.cue_type == CueType.WAIT:
+            dur_value = cue.wait_duration
+        else:
+            dur_value = cue.duration
         item = QTreeWidgetItem([
             cue.cue_number or str(index + 1),
             cue.cue_type,
             cue.name or "(naamloos)",
-            _fmt_duration(cue.duration if cue.cue_type == CueType.AUDIO else
-                          cue.wait_duration if cue.cue_type == CueType.WAIT else
-                          cue.duration),
+            _fmt_duration(dur_value),
             ContinueMode.LABELS.get(cue.continue_mode, ""),
             cue.state,
         ])
@@ -154,6 +166,50 @@ class CueListWidget(QTreeWidget):
                 color = STATE_COLORS.get(cue.state, QColor("#888"))
                 item.setForeground(5, QBrush(color))
                 return
+
+    def update_cue_display(self, cue_id: str) -> None:
+        """Update álle zichtbare kolommen van één cue zonder clear/rebuild.
+        Gebruikt door de inspector zodat keyboard-focus op spinboxen niet
+        verspringt als de gebruiker waardes aanpast."""
+        for i in range(self.topLevelItemCount()):
+            item = self.topLevelItem(i)
+            if item.data(0, Qt.ItemDataRole.UserRole) != cue_id:
+                continue
+            cue = self.workspace.find(cue_id)
+            if cue is None:
+                return
+            # Duur (zelfde logica als _make_item)
+            if cue.cue_type == CueType.VIDEO:
+                if cue.video_end_offset > 0:
+                    dur_value = max(0.0, cue.video_end_offset - cue.video_start_offset)
+                elif cue.video_file_duration > 0:
+                    dur_value = max(0.0, cue.video_file_duration - cue.video_start_offset)
+                else:
+                    dur_value = cue.duration
+            elif cue.cue_type == CueType.WAIT:
+                dur_value = cue.wait_duration
+            else:
+                dur_value = cue.duration
+            item.setText(0, cue.cue_number or str(i + 1))
+            item.setText(1, cue.cue_type)
+            item.setText(2, cue.name or "(naamloos)")
+            item.setText(3, _fmt_duration(dur_value))
+            item.setText(4, ContinueMode.LABELS.get(cue.continue_mode, ""))
+            item.setText(5, cue.state)
+            state_color = STATE_COLORS.get(cue.state, QColor("#888"))
+            item.setForeground(5, QBrush(state_color))
+            # Kleur-balk bijwerken
+            if cue.color:
+                full = QBrush(QColor(cue.color))
+                tint = QBrush(tint_for_row(cue.color))
+                item.setBackground(0, full)
+                for col in range(1, len(COLUMNS)):
+                    item.setBackground(col, tint)
+            else:
+                empty = QBrush()
+                for col in range(len(COLUMNS)):
+                    item.setBackground(col, empty)
+            return
 
     # ---- selectie & playhead ----------------------------------------------
 

--- a/livefire/ui/inspector.py
+++ b/livefire/ui/inspector.py
@@ -19,6 +19,7 @@ from ..cues import Cue, CueType, ContinueMode
 from ..engines.video import list_screens
 from ..workspace import Workspace
 from .style import CUE_COLORS
+from .video_preview import VideoPreviewWidget
 
 
 def _swatch_icon(hex_color: str, size: int = 14) -> QIcon:
@@ -46,6 +47,9 @@ class InspectorWidget(QWidget):
     _PER_CUE_ATTRS = frozenset({
         "cue_number", "name", "file_path", "notes", "target_cue_id",
         "trigger_osc",
+        # Trim-punten zijn bestand-specifiek; bulk-edit zou van één bestand
+        # naar ander bestand niet-zinvolle waardes toepassen.
+        "video_start_offset", "video_end_offset",
     })
 
     def __init__(self, workspace: Workspace, parent=None):
@@ -199,6 +203,25 @@ class InspectorWidget(QWidget):
         self.sp_video_fade_out.setToolTip("Fade-to-black aan het einde van de cue.")
         vl.addRow("Fade-in (s)", self.sp_video_fade_in)
         vl.addRow("Fade-out (s)", self.sp_video_fade_out)
+
+        # Thumbnail + timeline voor in/uit-punt scrubbing.
+        self.video_preview = VideoPreviewWidget()
+        vl.addRow(self.video_preview)
+
+        self.sp_video_in = self._spin_seconds(max_val=36000.0)
+        self.sp_video_in.setToolTip("In-punt (vanaf welk moment wordt afgespeeld).")
+        self.sp_video_out = self._spin_seconds(max_val=36000.0)
+        self.sp_video_out.setToolTip("Uit-punt (waar de cue eindigt). 0 = tot einde bestand.")
+        vl.addRow("In-punt (s)", self.sp_video_in)
+        vl.addRow("Uit-punt (s)", self.sp_video_out)
+
+        # Bidirectionele sync tussen timeline (drag) en spinboxes (veld).
+        self.video_preview.in_point_changed.connect(self._set_video_in_from_timeline)
+        self.video_preview.out_point_changed.connect(self._set_video_out_from_timeline)
+        self.video_preview.duration_detected.connect(self._on_video_duration_detected)
+        self.sp_video_in.valueChanged.connect(self._on_video_in_spin_changed)
+        self.sp_video_out.valueChanged.connect(self._on_video_out_spin_changed)
+
         lay.addWidget(self.grp_video)
 
         # ---- Wait ----------------------------------------------------------
@@ -290,6 +313,8 @@ class InspectorWidget(QWidget):
             self.cb_video_screen: ("video_output_screen", lambda: self.cb_video_screen.currentData()),
             self.sp_video_fade_in:  ("video_fade_in",     lambda: self.sp_video_fade_in.value()),
             self.sp_video_fade_out: ("video_fade_out",    lambda: self.sp_video_fade_out.value()),
+            self.sp_video_in:       ("video_start_offset", lambda: self.sp_video_in.value()),
+            self.sp_video_out:      ("video_end_offset",   lambda: self.sp_video_out.value()),
         }
 
         for w in (self.ed_number, self.ed_name, self.ed_path, self.ed_notes,
@@ -301,7 +326,8 @@ class InspectorWidget(QWidget):
         for w in (self.sp_pre, self.sp_dur, self.sp_post, self.sp_volume,
                   self.sp_start, self.sp_end, self.sp_fade_in, self.sp_fade_out,
                   self.sp_wait, self.sp_fade_target,
-                  self.sp_video_fade_in, self.sp_video_fade_out):
+                  self.sp_video_fade_in, self.sp_video_fade_out,
+                  self.sp_video_in, self.sp_video_out):
             w.valueChanged.connect(self._on_any_change)
         self.sp_loops.valueChanged.connect(self._on_any_change)
         self.cb_type.currentTextChanged.connect(self._on_type_change)
@@ -410,6 +436,16 @@ class InspectorWidget(QWidget):
             self.cb_video_screen.setCurrentIndex(idx_screen)
         self.sp_video_fade_in.setValue(cue.video_fade_in)
         self.sp_video_fade_out.setValue(cue.video_fade_out)
+        self.sp_video_in.setValue(cue.video_start_offset)
+        self.sp_video_out.setValue(cue.video_end_offset)
+
+        # Thumbnail-preview alleen laden voor single-select VIDEO-cues.
+        if not multi and cue.cue_type == CueType.VIDEO and cue.file_path:
+            self.video_preview.load(
+                cue.file_path, cue.video_start_offset, cue.video_end_offset,
+            )
+        else:
+            self.video_preview.load("", 0.0, 0.0)
 
         self.refresh_targets()
         idx = self.cb_target.findData(cue.target_cue_id)
@@ -473,6 +509,54 @@ class InspectorWidget(QWidget):
         if idx < 0:
             idx = 0  # "Geen"
         self.cb_color.setCurrentIndex(idx)
+
+    def _on_video_duration_detected(self, seconds: float) -> None:
+        """Preview ontdekte de file-duur; cache 'm op de cue zodat de cuelist
+        de 'Duur'-kolom correct kan tonen ook als video_end_offset = 0.
+        Bewust géén workspace.dirty — dit is een metadata-cache, geen edit."""
+        if self.cue is None or self.cue.cue_type != CueType.VIDEO:
+            return
+        if abs(self.cue.video_file_duration - seconds) < 0.01:
+            return  # al gecached
+        self.cue.video_file_duration = seconds
+        # Signaal naar mainwindow voor cuelist-refresh, maar workspace blijft schoon.
+        self.cue_changed.emit(self.cue)
+
+    def _set_video_in_from_timeline(self, seconds: float) -> None:
+        self.sp_video_in.blockSignals(True)
+        self.sp_video_in.setValue(seconds)
+        self.sp_video_in.blockSignals(False)
+        if not self._updating and self.cues:
+            for c in self.cues[:1]:  # file_path-samenhangend → per-cue veld
+                c.video_start_offset = seconds
+            self.workspace.dirty = True
+            self.cue_changed.emit(self.cues[0])
+
+    def _set_video_out_from_timeline(self, seconds: float) -> None:
+        self.sp_video_out.blockSignals(True)
+        self.sp_video_out.setValue(seconds)
+        self.sp_video_out.blockSignals(False)
+        if not self._updating and self.cues:
+            for c in self.cues[:1]:
+                c.video_end_offset = seconds
+            self.workspace.dirty = True
+            self.cue_changed.emit(self.cues[0])
+
+    def _on_video_in_spin_changed(self, v: float) -> None:
+        """Spinbox bewoog het in-punt — sync timeline én scrub preview naar
+        dat frame zodat je ziet waar je begint."""
+        out = self.sp_video_out.value() or self.video_preview.timeline.out_point()
+        self.video_preview.set_markers(v, out)
+        self.video_preview.scrub_to(v)
+
+    def _on_video_out_spin_changed(self, v: float) -> None:
+        """Spinbox bewoog het uit-punt — scrub naar dat frame. v=0 betekent
+        'tot einde', dan scrubben we naar de totale duur."""
+        in_ = self.sp_video_in.value()
+        tl_out = self.video_preview.timeline.out_point()
+        visual_out = v if v > 0 else tl_out
+        self.video_preview.set_markers(in_, v)
+        self.video_preview.scrub_to(visual_out)
 
     def _browse_video(self) -> None:
         path, _ = QFileDialog.getOpenFileName(

--- a/livefire/ui/mainwindow.py
+++ b/livefire/ui/mainwindow.py
@@ -374,8 +374,12 @@ class MainWindow(QMainWindow):
         # op, zodat de inspector multi-select kan tonen.
         self.inspector.set_cues(self.cue_list.selected_cues())
 
-    def _on_inspector_changed(self, _cue: Cue) -> None:
-        self.cue_list.refresh()
+    def _on_inspector_changed(self, cue: Cue) -> None:
+        # Targeted update per cue zodat keyboard-focus op inspector-spinboxen
+        # niet naar de cuelist verspringt bij elke value-change. Bij multi-
+        # select doen we 'm voor alle geselecteerde cues.
+        for c in self.inspector.cues or [cue]:
+            self.cue_list.update_cue_display(c.id)
         self._sync_title()
 
     def _on_cue_state_changed(self, cue_id: str) -> None:

--- a/livefire/ui/style.py
+++ b/livefire/ui/style.py
@@ -1,6 +1,12 @@
 """Dark-theme stylesheet en kleurconstanten."""
 
-from PyQt6.QtGui import QColor
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from PyQt6.QtCore import QPointF, Qt
+from PyQt6.QtGui import QColor, QPainter, QPixmap, QPolygonF
 
 
 # ---- palette ---------------------------------------------------------------
@@ -50,7 +56,43 @@ def tint_for_row(hex_color: str, alpha: int = 110) -> QColor:
     return c
 
 
-STYLESHEET = f"""
+def _make_arrow_pixmap(direction: str, color: str = TEXT) -> str:
+    """Teken een 9×9 driehoek-pixmap en schrijf naar tempdir. Retourneert het
+    pad met forward-slashes zodat het veilig in een Qt-stylesheet url() past.
+    Qt accepteert geen border-triangle-truc voor ::up-arrow/::down-arrow; een
+    image: url() is wel betrouwbaar."""
+    size = 9
+    pm = QPixmap(size, size)
+    pm.fill(Qt.GlobalColor.transparent)
+    p = QPainter(pm)
+    p.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+    p.setPen(Qt.PenStyle.NoPen)
+    p.setBrush(QColor(color))
+    if direction == "up":
+        poly = QPolygonF([QPointF(1, 7), QPointF(size - 1, 7), QPointF(size / 2, 2)])
+    else:
+        poly = QPolygonF([QPointF(1, 2), QPointF(size - 1, 2), QPointF(size / 2, 7)])
+    p.drawPolygon(poly)
+    p.end()
+    out = Path(tempfile.gettempdir()) / f"livefire_arrow_{direction}.png"
+    pm.save(str(out), "PNG")
+    return str(out).replace("\\", "/")
+
+
+def build_stylesheet() -> str:
+    """Genereer de stylesheet. Moet ná QApplication()-init worden aangeroepen
+    omdat QPixmap een GUI-context nodig heeft voor arrow-icons."""
+    arrow_up = _make_arrow_pixmap("up")
+    arrow_down = _make_arrow_pixmap("down")
+    return _STYLESHEET_TEMPLATE.format(
+        BG_DARK=BG_DARK, BG_MID=BG_MID, BG_LIGHT=BG_LIGHT,
+        TEXT=TEXT, TEXT_DIM=TEXT_DIM, ACCENT=ACCENT,
+        OK=OK, ERR=ERR, SEL_BG=SEL_BG, BORDER=BORDER,
+        ARROW_UP=arrow_up, ARROW_DOWN=arrow_down,
+    )
+
+
+_STYLESHEET_TEMPLATE = """
 QMainWindow, QWidget {{
     background-color: {BG_DARK};
     color: {TEXT};
@@ -145,6 +187,47 @@ QComboBox::drop-down {{ border: none; }}
 QLineEdit:focus, QSpinBox:focus, QDoubleSpinBox:focus,
 QComboBox:focus, QPlainTextEdit:focus {{
     border: 1px solid {ACCENT};
+}}
+
+/* Spinbox up/down knoppen. In Qt-stylesheet-mode tekent Qt géén native
+   pijl-glyph meer — we bouwen de driehoek zelf met border-triangles. */
+QSpinBox, QDoubleSpinBox {{
+    padding-right: 18px;
+}}
+QSpinBox::up-button, QDoubleSpinBox::up-button {{
+    subcontrol-origin: border;
+    subcontrol-position: top right;
+    width: 16px;
+    background: {BG_LIGHT};
+    border-left: 1px solid {BORDER};
+    border-top-right-radius: 3px;
+}}
+QSpinBox::down-button, QDoubleSpinBox::down-button {{
+    subcontrol-origin: border;
+    subcontrol-position: bottom right;
+    width: 16px;
+    background: {BG_LIGHT};
+    border-left: 1px solid {BORDER};
+    border-top: 1px solid {BORDER};
+    border-bottom-right-radius: 3px;
+}}
+QSpinBox::up-button:hover, QDoubleSpinBox::up-button:hover,
+QSpinBox::down-button:hover, QDoubleSpinBox::down-button:hover {{
+    background: #3d3d3d;
+}}
+QSpinBox::up-button:pressed, QDoubleSpinBox::up-button:pressed,
+QSpinBox::down-button:pressed, QDoubleSpinBox::down-button:pressed {{
+    background: {SEL_BG};
+}}
+QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {{
+    image: url({ARROW_UP});
+    width: 9px;
+    height: 9px;
+}}
+QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {{
+    image: url({ARROW_DOWN});
+    width: 9px;
+    height: 9px;
 }}
 
 QGroupBox {{

--- a/livefire/ui/video_preview.py
+++ b/livefire/ui/video_preview.py
@@ -1,0 +1,330 @@
+"""Inspector-preview voor video-cues: klein VLC-paneel + tijdlijn-widget
+met sleepbare in- en uit-punt markers (live scrub)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from PyQt6.QtCore import Qt, QTimer, pyqtSignal
+from PyQt6.QtGui import QColor, QPainter, QBrush, QPen
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QFrame, QLabel
+
+try:
+    import vlc  # type: ignore[import-not-found]
+    _VLC_OK = True
+except Exception:
+    vlc = None  # type: ignore[assignment]
+    _VLC_OK = False
+
+
+class TimelineWidget(QWidget):
+    """Horizontale tijdlijn met sleepbare in/uit-markers. Geeft realtime
+    scrub-positie door terwijl de gebruiker sleept."""
+
+    in_changed = pyqtSignal(float)       # seconden, commit bij release
+    out_changed = pyqtSignal(float)
+    scrubbing = pyqtSignal(float)         # live, terwijl user sleept
+
+    _HANDLE_W = 8
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setMinimumHeight(36)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._duration: float = 0.0
+        self._in_s: float = 0.0
+        self._out_s: float = 0.0
+        self._dragging: Optional[str] = None  # "in" | "out" | None
+
+    # ---- public API -------------------------------------------------------
+
+    def set_duration(self, seconds: float) -> None:
+        self._duration = max(0.0, seconds)
+        if self._out_s <= 0 or self._out_s > self._duration:
+            self._out_s = self._duration
+        self.update()
+
+    def set_in_point(self, s: float) -> None:
+        self._in_s = max(0.0, min(s, self._duration or s))
+        self.update()
+
+    def set_out_point(self, s: float) -> None:
+        # 0 betekent "tot einde" in ons datamodel; toon dan de volledige duur.
+        visual_out = s if s > 0 else self._duration
+        self._out_s = max(self._in_s, min(visual_out, self._duration or visual_out))
+        self.update()
+
+    def in_point(self) -> float:
+        return self._in_s
+
+    def out_point(self) -> float:
+        return self._out_s
+
+    # ---- paint -------------------------------------------------------------
+
+    def paintEvent(self, _event) -> None:
+        p = QPainter(self)
+        p.setRenderHint(QPainter.RenderHint.Antialiasing)
+        w = self.width()
+        h = self.height()
+        track_y = h // 2 - 4
+        # Track background
+        p.fillRect(0, track_y, w, 8, QColor("#2a2a2a"))
+        if self._duration <= 0:
+            p.setPen(QColor("#9a9a9a"))
+            p.drawText(self.rect(), Qt.AlignmentFlag.AlignCenter,
+                       "Geen video geladen")
+            return
+        # Active range (between in and out)
+        x_in = self._time_to_x(self._in_s)
+        x_out = self._time_to_x(self._out_s)
+        p.fillRect(x_in, track_y, max(0, x_out - x_in), 8, QColor("#3aa2e6"))
+        # Handles (in = groen, out = rood)
+        self._draw_handle(p, x_in, h, QColor("#2e8b57"))
+        self._draw_handle(p, x_out, h, QColor("#c0392b"))
+
+    def _draw_handle(self, p: QPainter, x: int, h: int, color: QColor) -> None:
+        w = self._HANDLE_W
+        p.setBrush(QBrush(color))
+        p.setPen(QPen(QColor("#e0e0e0"), 1))
+        p.drawRect(x - w // 2, 2, w, h - 4)
+
+    def _time_to_x(self, t: float) -> int:
+        if self._duration <= 0:
+            return 0
+        return int(t / self._duration * self.width())
+
+    def _x_to_time(self, x: float) -> float:
+        if self.width() <= 0 or self._duration <= 0:
+            return 0.0
+        t = x / self.width() * self._duration
+        return max(0.0, min(t, self._duration))
+
+    # ---- interaction -------------------------------------------------------
+
+    def mousePressEvent(self, e) -> None:
+        if self._duration <= 0:
+            return
+        x = e.position().x()
+        x_in = self._time_to_x(self._in_s)
+        x_out = self._time_to_x(self._out_s)
+        # Pak de dichtstbijzijnde handle.
+        self._dragging = "in" if abs(x - x_in) <= abs(x - x_out) else "out"
+        self._update_drag(x)
+
+    def mouseMoveEvent(self, e) -> None:
+        if self._dragging is None:
+            return
+        self._update_drag(e.position().x())
+
+    def mouseReleaseEvent(self, _event) -> None:
+        if self._dragging == "in":
+            self.in_changed.emit(self._in_s)
+        elif self._dragging == "out":
+            self.out_changed.emit(self._out_s)
+        self._dragging = None
+
+    def _update_drag(self, x: float) -> None:
+        t = self._x_to_time(x)
+        if self._dragging == "in":
+            self._in_s = min(t, self._out_s)
+        else:
+            self._out_s = max(t, self._in_s)
+        self.scrubbing.emit(t)
+        self.update()
+
+
+class VideoPreviewWidget(QWidget):
+    """Klein VLC-paneel + tijdlijn voor in/uit-punt scrubbing. Gebruikt een
+    eigen VLC-instance met --no-audio zodat scrubben stil is en los staat
+    van de hoofd-engine."""
+
+    in_point_changed = pyqtSignal(float)
+    out_point_changed = pyqtSignal(float)
+    duration_detected = pyqtSignal(float)   # file-duur in seconden (cache)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        lay = QVBoxLayout(self)
+        lay.setContentsMargins(0, 0, 0, 0)
+        lay.setSpacing(4)
+
+        self.display = QFrame()
+        self.display.setMinimumHeight(180)
+        self.display.setStyleSheet("background: black; border: 1px solid #3a3a3a;")
+        # Vraag een native handle alleen op dit widget; voorkomt dat Qt ook
+        # alle parents (scrollarea/inspector/mainwindow) native maakt — dat
+        # breekt keyboard focus-routing naar spinboxes.
+        self.display.setAttribute(Qt.WidgetAttribute.WA_NativeWindow, True)
+        self.display.setAttribute(Qt.WidgetAttribute.WA_DontCreateNativeAncestors, True)
+        # Display-widget mag geen keyboard focus krijgen; die hoort naar
+        # de inspector-velden te gaan.
+        self.display.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        lay.addWidget(self.display)
+
+        self.timeline = TimelineWidget()
+        lay.addWidget(self.timeline)
+
+        self.lbl_info = QLabel("—")
+        self.lbl_info.setStyleSheet("color: #9a9a9a;")
+        lay.addWidget(self.lbl_info)
+
+        # VLC preview-player (eigen instance — geïsoleerd van de hoofd-engine).
+        self._instance = None
+        self._player = None
+        if _VLC_OK:
+            try:
+                self._instance = vlc.Instance("--no-audio", "--quiet", "--no-video-title-show")  # type: ignore[union-attr]
+                self._player = self._instance.media_player_new()
+            except Exception:
+                self._instance = None
+                self._player = None
+
+        self._duration: float = 0.0
+        self._pending_hwnd = False
+        self._current_path: str = ""
+
+        # Debounce voor pauzeren ná een scrub-burst: terwijl de gebruiker sleept
+        # of rapid klikt op spinbox-pijltjes houden we de player spelend zodat
+        # VLC niet per scrub hoeft te re-decoderen (wat stottert).
+        self._repause_timer = QTimer(self)
+        self._repause_timer.setSingleShot(True)
+        self._repause_timer.setInterval(150)
+        self._repause_timer.timeout.connect(self._repause)
+
+        self.timeline.scrubbing.connect(self._scrub_to)
+        self.timeline.in_changed.connect(self.in_point_changed.emit)
+        self.timeline.out_changed.connect(self.out_point_changed.emit)
+
+    # ---- public API -------------------------------------------------------
+
+    def load(self, path: str, in_s: float = 0.0, out_s: float = 0.0) -> None:
+        """Laad een video en toon het eerste frame. Zet in/uit-markers naar
+        de meegegeven waardes (out_s=0 betekent "tot einde")."""
+        self._current_path = path
+        if not path or not Path(path).is_file() or self._player is None:
+            self._duration = 0.0
+            self.timeline.set_duration(0.0)
+            self.lbl_info.setText("—")
+            if self._player is not None:
+                self._player.stop()
+            return
+        self._attach_hwnd_if_needed()
+        media = self._instance.media_new(path)  # type: ignore[union-attr]
+        self._player.set_media(media)
+        self._player.play()
+        # libVLC heeft wisselend veel tijd nodig om metadata te vullen; we
+        # pollen get_length() tot 'ie > 0 is of een ruime timeout verstrijkt.
+        self._load_retries = 0
+        QTimer.singleShot(100, lambda: self._after_load(in_s, out_s))
+
+    def set_markers(self, in_s: float, out_s: float) -> None:
+        """Zet timeline-markers zonder de video opnieuw te laden."""
+        self.timeline.set_in_point(in_s)
+        self.timeline.set_out_point(out_s)
+
+    def scrub_to(self, seconds: float) -> None:
+        """Spring de preview-player naar een specifiek tijdstip. Gebruikt door
+        de inspector als de spinboxen het in- of uit-punt verplaatsen."""
+        self._scrub_to(seconds)
+
+    def shutdown(self) -> None:
+        if self._player is not None:
+            try:
+                self._player.stop()
+                self._player.release()
+            except Exception:
+                pass
+        if self._instance is not None:
+            try:
+                self._instance.release()
+            except Exception:
+                pass
+        self._player = None
+        self._instance = None
+
+    # ---- intern ------------------------------------------------------------
+
+    def _attach_hwnd_if_needed(self) -> None:
+        if self._player is None or self._pending_hwnd:
+            return
+        try:
+            self._player.set_hwnd(int(self.display.winId()))
+            self._pending_hwnd = True
+        except Exception:
+            pass
+
+    def _after_load(self, in_s: float, out_s: float) -> None:
+        if self._player is None:
+            return
+        length_ms = self._player.get_length()
+        if length_ms <= 0 and self._load_retries < 30:
+            # ~3s totaal (30 × 100 ms) om metadata binnen te laten komen
+            self._load_retries += 1
+            QTimer.singleShot(100, lambda: self._after_load(in_s, out_s))
+            return
+        self._player.set_pause(True)
+        self._duration = length_ms / 1000.0 if length_ms > 0 else 0.0
+        self.timeline.set_duration(self._duration)
+        self.timeline.set_in_point(in_s)
+        self.timeline.set_out_point(out_s)
+        if in_s > 0:
+            self._scrub_to(in_s)
+        self._update_info()
+        if self._duration > 0:
+            self.duration_detected.emit(self._duration)
+
+    def _scrub_to(self, seconds: float) -> None:
+        if self._player is None or self._duration <= 0:
+            return
+        # Clamp net vóór het einde: libVLC komt in Ended state zodra je op
+        # (of voorbij) het laatste frame seekt, en negeert daarna verdere
+        # set_time() calls — de preview lijkt dan definitief te hangen.
+        seconds = max(0.0, min(seconds, self._duration - 0.05))
+        # Recover als de player toch al Ended/Stopped is (bijv. na natuurlijk
+        # einde of een eerdere end-seek): herstart voor de set_time.
+        self._ensure_playable()
+        # libVLC op Windows rendert geen nieuw frame als je set_time() op een
+        # paused player aanroept — blijf tijdens een scrub-burst gewoon
+        # spelend en pauzeer pas na 150 ms stilte (zie _repause_timer).
+        self._player.set_pause(False)
+        self._player.set_time(int(seconds * 1000))
+        self._update_info(scrub=seconds)
+        self._repause_timer.start()
+
+    def _ensure_playable(self) -> None:
+        """Herstart player als ie in Ended/Stopped/Error state staat, anders
+        negeert libVLC verdere set_time() calls."""
+        if self._player is None or not _VLC_OK:
+            return
+        try:
+            state = self._player.get_state()
+        except Exception:
+            return
+        if state in (vlc.State.Ended, vlc.State.Stopped, vlc.State.Error):  # type: ignore[union-attr]
+            try:
+                self._player.stop()
+                self._player.play()
+            except Exception:
+                pass
+
+    def _repause(self) -> None:
+        if self._player is not None:
+            try:
+                self._player.set_pause(True)
+            except Exception:
+                pass
+
+    def _update_info(self, scrub: float | None = None) -> None:
+        if self._duration <= 0:
+            self.lbl_info.setText("—")
+            return
+        in_s = self.timeline.in_point()
+        out_s = self.timeline.out_point()
+        parts = [f"Duur: {self._duration:.1f}s",
+                 f"In: {in_s:.2f}s",
+                 f"Uit: {out_s:.2f}s"]
+        if scrub is not None:
+            parts.append(f"Scrub: {scrub:.2f}s")
+        self.lbl_info.setText("  ·  ".join(parts))

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -34,7 +34,9 @@ def test_roundtrip_preserves_all_cue_types(tmp_path: Path):
                    file_path="C:/tmp/movie.mp4",
                    video_output_screen=1,
                    video_fade_in=0.5,
-                   video_fade_out=1.5))
+                   video_fade_out=1.5,
+                   video_start_offset=2.0,
+                   video_end_offset=8.5))
 
     p = tmp_path / "test.livefire"
     ws.save(p)
@@ -56,6 +58,8 @@ def test_roundtrip_preserves_all_cue_types(tmp_path: Path):
         assert orig.video_output_screen == got.video_output_screen
         assert orig.video_fade_in == got.video_fade_in
         assert orig.video_fade_out == got.video_fade_out
+        assert orig.video_start_offset == got.video_start_offset
+        assert orig.video_end_offset == got.video_end_offset
 
 
 def test_save_writes_current_format_version(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Video-cues krijgen een in/uit-punt (trim) via libVLC's `:start-time` / `:stop-time`. Inspector toont een nieuwe preview-widget met VLC-thumbnail + sleepbare tijdlijn-markers en spinboxen die bidirectioneel syncen en de preview live mee scrubben.
- Meeliftende fixes: `is_playing()` state-based zodat AUTO_FOLLOW werkt bij een stop-time; `get_remaining()` en de Duur-kolom in de cuelist respecteren het getrimde eind; cuelist-rij-update is nu targeted (geen focus-loss op spinboxen); spinbox-pijltjes weer zichtbaar via expliciete arrow-pixmaps (`build_stylesheet()`).
- Workspace-roundtrip uitgebreid voor `video_start_offset` / `video_end_offset` (test in `tests/test_workspace.py`); `video_file_duration` wordt door de preview gecachet voor correcte Duur-kolom zonder geladen file.

## Test plan
- [ ] `pytest tests/test_workspace.py` — roundtrip met start/end offsets groen
- [ ] App starten met `.venv\Scripts\python.exe -m livefire`, video-cue maken, in/uit-punt slepen op timeline én via spinboxen — preview scrubt mee, geen lock-up bij end-of-stream
- [ ] GO op een getrimde video-cue — speelt vanaf in-punt en stopt op uit-punt, AUTO_FOLLOW vuurt op het getrimde einde
- [ ] Cuelist Duur-kolom toont (end - start) bij getrimde cue's; `file_duration - start` bij open uit-punt
- [ ] Spinbox up/down-pijltjes zichtbaar in het dark-theme (volume, in/uit, fades, pre/post)

🤖 Generated with [Claude Code](https://claude.com/claude-code)