### PR TITLE
fix(video): geen UI-flits tussen twee video-cues bij AUTO_FOLLOW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Alle noemenswaardige wijzigingen aan dit project. Format volgens
 
 ## [Unreleased]
 
+### Verholpen
+- Geen UI-flits meer tussen twee opeenvolgende video-cues bij
+  AUTO_FOLLOW. De oude `VideoWindow` wordt eerst gepauzeerd (laatste
+  frame blijft staan) en pas 300 ms later geclosed/released, zodat de
+  volgende videowindow er bovenop kan komen voordat de oude verdwijnt.
+
 ### Toegevoegd
 - **Trim** (in/uit-punt) op Video-cues. De inspector toont een
   preview-widget met VLC-thumbnail en sleepbare tijdlijn-markers; daarnaast

--- a/livefire/engines/video.py
+++ b/livefire/engines/video.py
@@ -262,16 +262,33 @@ class VideoEngine(QObject):
         entry = self._playing.pop(cue_id, None)
         if entry is None:
             return
-        try:
-            entry["player"].stop()
-            entry["player"].release()
-        except Exception:
-            pass
-        try:
-            entry["window"].close()
-            entry["window"].deleteLater()
-        except Exception:
-            pass
+        player = entry.get("player")
+        window = entry.get("window")
+        # Pauzeer eerst zodat het laatste frame zichtbaar blijft; ruim daarna
+        # met een korte delay op. Bij AUTO_FOLLOW van video → video heeft de
+        # volgende videowindow zo de tijd om fullscreen op te komen vóór deze
+        # weggaat — anders zie je tussendoor heel even de desktop/UI flitsen.
+        if player is not None:
+            try:
+                player.set_pause(True)
+            except Exception:
+                pass
+
+        def _cleanup() -> None:
+            try:
+                if player is not None:
+                    player.stop()
+                    player.release()
+            except Exception:
+                pass
+            try:
+                if window is not None:
+                    window.close()
+                    window.deleteLater()
+            except Exception:
+                pass
+
+        QTimer.singleShot(300, _cleanup)
 
     def _on_end_reached(self, cue_id: str) -> None:
         """Draait op UI-thread via QTimer.singleShot. Signaleer aan de


### PR DESCRIPTION
## Summary
- Bij AUTO_FOLLOW van video → video sloot \`_hard_stop\` de oude \`VideoWindow\` synchroon, terwijl de nieuwe cue in dezelfde tick z'n window pas opbouwde + libVLC nog moest decoderen. Tussen die twee in werd de desktop/UI heel even zichtbaar.
- Fix: pauzeer de oude player eerst (laatste frame blijft staan) en defer de window-close + player-release naar \`QTimer.singleShot(300ms)\`. De volgende videowindow heeft daardoor de tijd om fullscreen op te komen vóór de oude verdwijnt.

## Test plan
- [ ] Twee video-cues achter elkaar met AUTO_FOLLOW — geen UI-flits, geen zichtbare zwarte gap meer
- [ ] Handmatige Stop op een video-cue — window sluit nog steeds, alleen 300 ms later

🤖 Generated with [Claude Code](https://claude.com/claude-code)