### PR TITLE
feat(presentation): PowerPoint-cues via COM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Alle noemenswaardige wijzigingen aan dit project. Format volgens
 ## [Unreleased]
 
 ### Toegevoegd
+- **Presentatie-cue** (PowerPoint via COM). Nieuw cue-type met acties
+  Open / Volgende slide / Vorige slide / Ga naar slide / Sluit. Audio,
+  video, animaties, transities en hyperlinks blijven werken want
+  PowerPoint blijft de speler — liveFire is alleen de cue-trigger.
+  AUTO_FOLLOW op een Open-cue wacht tot de slideshow klaar is, sluit
+  de presentatie automatisch (geen "klik om af te sluiten"-zwarte
+  slide), en minimaliseert de PowerPoint-editor zodat die nooit over
+  een volgende cue blijft staan. Drag-and-drop van .pptx/.ppt/.pptm,
+  Ctrl+9 voor nieuwe cue, eigen knop in de toolbar. Vereist
+  Microsoft PowerPoint en `pywin32` op de showmachine; engine
+  registreert zich in Engine-status, degraded gracefully zonder.
+
+### Toegevoegd
 - **App-icoon** (`livefire/resources/icon.png`) zichtbaar in titlebar,
   Alt-Tab en taskbar. Op Windows wordt een AppUserModelID gezet zodat
   de taskbar liveFire niet onder "Python" groepeert.

--- a/livefire/cues/__init__.py
+++ b/livefire/cues/__init__.py
@@ -1,3 +1,3 @@
-from .base import Cue, CueType, ContinueMode
+from .base import Cue, CueType, ContinueMode, PresentationAction
 
-__all__ = ["Cue", "CueType", "ContinueMode"]
+__all__ = ["Cue", "CueType", "ContinueMode", "PresentationAction"]

--- a/livefire/cues/base.py
+++ b/livefire/cues/base.py
@@ -14,6 +14,7 @@ class CueType:
 
     AUDIO = "Audio"
     VIDEO = "Video"
+    PRESENTATION = "Presentation"
     GROUP = "Group"
     WAIT = "Wait"
     STOP = "Stop"
@@ -25,7 +26,26 @@ class CueType:
     # MIDI  = "MIDI"    -> v0.4.x
     # DMX   = "DMX"     -> v0.5.0
 
-    ALL = [AUDIO, VIDEO, GROUP, WAIT, STOP, FADE, START, MEMO]
+    ALL = [AUDIO, VIDEO, PRESENTATION, GROUP, WAIT, STOP, FADE, START, MEMO]
+
+
+class PresentationAction:
+    """Sub-actie van een Presentation-cue."""
+
+    OPEN = "open"
+    NEXT = "next"
+    PREVIOUS = "previous"
+    GOTO = "goto"
+    CLOSE = "close"
+
+    LABELS = {
+        OPEN: "Open presentatie",
+        NEXT: "Volgende slide",
+        PREVIOUS: "Vorige slide",
+        GOTO: "Ga naar slide",
+        CLOSE: "Sluit presentatie",
+    }
+    ALL = [OPEN, NEXT, PREVIOUS, GOTO, CLOSE]
 
 
 class ContinueMode:
@@ -77,6 +97,10 @@ class Cue:
     video_start_offset: float = 0.0  # in-punt in seconden (0 = vanaf begin)
     video_end_offset: float = 0.0    # uit-punt in seconden (0 = tot einde)
     video_file_duration: float = 0.0 # cache van file-duur; auto-gevuld door preview
+
+    # PowerPoint-presentatie
+    presentation_action: str = PresentationAction.OPEN
+    presentation_slide: int = 1     # alleen voor GOTO
 
     # Fade-target
     target_cue_id: str = ""    # voor Stop, Fade, Start

--- a/livefire/engines/__init__.py
+++ b/livefire/engines/__init__.py
@@ -1,6 +1,10 @@
 from .audio import AudioEngine
 from .osc import OscInputEngine
+from .powerpoint import PowerPointEngine
 from .video import VideoEngine
 from . import registry
 
-__all__ = ["AudioEngine", "OscInputEngine", "VideoEngine", "registry"]
+__all__ = [
+    "AudioEngine", "OscInputEngine", "PowerPointEngine", "VideoEngine",
+    "registry",
+]

--- a/livefire/engines/powerpoint.py
+++ b/livefire/engines/powerpoint.py
@@ -1,0 +1,304 @@
+"""PowerPoint-engine via COM-besturing.
+
+Scope MVP:
+- Eén actieve presentatie tegelijk (open + slideshow)
+- Acties: open, next-slide, previous-slide, goto-slide, close
+- Audio + video + animaties + transities + hyperlinks blijven werken want
+  PowerPoint blijft de daadwerkelijke speler; liveFire is alleen de
+  cue-trigger.
+
+Vereist: Windows + Microsoft PowerPoint geïnstalleerd. Engine degradeert
+gracefully op machines zonder Office (alle calls return False met een
+duidelijke foutmelding).
+"""
+
+from __future__ import annotations
+
+import ctypes
+import sys
+import time
+from pathlib import Path
+
+from PyQt6.QtCore import QObject, pyqtSignal
+
+from .registry import EngineStatus, register
+
+
+# Optionele dependency — engine werkt degraded zonder.
+_COM_OK = False
+_COM_ERR = ""
+if sys.platform == "win32":
+    try:
+        import win32com.client  # type: ignore[import-not-found]
+        import pythoncom  # type: ignore[import-not-found]
+        _COM_OK = True
+    except Exception as _e:
+        _COM_ERR = f"pywin32 niet geladen: {_e}"
+else:
+    _COM_ERR = "PowerPoint COM is alleen beschikbaar op Windows"
+
+
+# COM-constanten die we anders dynamisch zouden moeten ophalen.
+_PP_SHOW_TYPE_KIOSK = 1   # ppShowTypeKiosk — slideshow blijft draaien
+_PP_SLIDE_SHOW_DONE = 5   # ppSlideShowDone
+_PP_WINDOW_MINIMIZED = 2  # ppWindowMinimized — verbergt de editor-window
+
+
+class PowerPointEngine(QObject):
+    """Beheert één PowerPoint Application + actieve Presentation."""
+
+    presentation_opened = pyqtSignal(str)   # file_path
+    presentation_closed = pyqtSignal()
+
+    def __init__(self, parent: QObject | None = None):
+        super().__init__(parent)
+        self._app = None        # PowerPoint.Application (COM)
+        self._presentation = None
+        self._current_path: str = ""
+        # Of we PowerPoint zelf hebben gestart (en dus mogen quitten bij
+        # shutdown). Als de gebruiker PowerPoint al open had hebben we de
+        # bestaande instance overgenomen — niet stiekem afsluiten.
+        self._we_started_app = False
+
+    @property
+    def available(self) -> bool:
+        return _COM_OK
+
+    # ---- public API --------------------------------------------------------
+
+    def open(self, file_path: str) -> tuple[bool, str]:
+        """Open een .pptx en start direct de slideshow."""
+        if not _COM_OK:
+            return False, _COM_ERR
+        path = Path(file_path)
+        if not path.is_file():
+            return False, f"Bestand niet gevonden: {path}"
+
+        try:
+            # COM moet per thread geïnitialiseerd worden; doe het hier zodat
+            # de Qt-hoofdthread klaar is om PowerPoint te besturen.
+            pythoncom.CoInitialize()
+        except Exception:
+            pass
+
+        # Sluit eventuele vorige presentatie van ons.
+        self._close_presentation_if_any()
+
+        try:
+            if self._app is None:
+                # GetActiveObject gebruikt een lopende PowerPoint als die er
+                # is, anders Dispatch() start 'm. We onthouden of we 'm zelf
+                # opstartten zodat we niet abrupt iemands geopende slides
+                # afsluiten.
+                try:
+                    self._app = win32com.client.GetActiveObject(
+                        "PowerPoint.Application"
+                    )
+                    self._we_started_app = False
+                except Exception:
+                    self._app = win32com.client.Dispatch(
+                        "PowerPoint.Application"
+                    )
+                    self._we_started_app = True
+                self._app.Visible = True
+        except Exception as e:
+            return False, f"Kon PowerPoint niet starten: {e}"
+
+        # Open zonder readonly-flag: sommige presentaties (Protected View,
+        # buiten Trusted Locations, OneDrive-streams) weigeren read-only en
+        # gooien dan een -2147352567 / "PowerPoint could not open the file".
+        # WithWindow=True zorgt dat de slideshow z'n eigen fullscreen-venster
+        # krijgt; PowerPoint kiest zelf het juiste output-scherm.
+        full_path = str(path.resolve())
+        try:
+            self._presentation = self._app.Presentations.Open(full_path)
+        except Exception as e:
+            return False, f"Kon presentatie niet openen: {e}"
+
+        # Minimaliseer de editor-window meteen — de slideshow draait straks
+        # in een eigen fullscreen window dat hier los van staat. Anders zie
+        # je de PowerPoint-UI achter de slideshow.
+        try:
+            for i in range(1, self._presentation.Windows.Count + 1):
+                self._presentation.Windows(i).WindowState = _PP_WINDOW_MINIMIZED
+        except Exception:
+            pass
+
+        try:
+            settings = self._presentation.SlideShowSettings
+            settings.ShowType = _PP_SHOW_TYPE_KIOSK
+            slideshow_window = settings.Run()
+        except Exception as e:
+            return False, f"Kon slideshow niet starten: {e}"
+
+        # PowerPoint slideshow opent vaak achter onze Qt-mainwindow (zeker
+        # na een fullscreen video-cue). We forceren 'm naar voren via:
+        #   1. Hef Windows' foreground-lock op (ASFW_ANY = -1)
+        #   2. Activeer PowerPoint op COM-niveau
+        #   3. Activate() op de SlideShowWindow zelf
+        #   4. Win32 SetForegroundWindow + SwitchToThisWindow op de HWND,
+        #      met een Alt-keystroke om de focus-token vrij te geven.
+        try:
+            ctypes.windll.user32.AllowSetForegroundWindow(-1)
+        except Exception:
+            pass
+        try:
+            self._app.Activate()
+        except Exception:
+            pass
+
+        # Geef PowerPoint even tijd om de slideshow daadwerkelijk te
+        # tonen voordat we de HWND opvragen — anders is HWND nog 0.
+        hwnd = 0
+        for _ in range(20):  # ~1 s
+            try:
+                hwnd = int(slideshow_window.HWND)
+            except Exception:
+                hwnd = 0
+            if hwnd:
+                break
+            time.sleep(0.05)
+
+        try:
+            slideshow_window.Activate()
+        except Exception:
+            pass
+
+        if hwnd:
+            try:
+                user32 = ctypes.windll.user32
+                # VK_MENU = 0x12 ; KEYEVENTF_KEYUP = 0x02
+                user32.keybd_event(0x12, 0, 0, 0)
+                user32.keybd_event(0x12, 0, 0x02, 0)
+                user32.SetForegroundWindow(hwnd)
+                # SwitchToThisWindow is undocumented maar betrouwbaar voor
+                # cross-process focus na een net-getoonde window.
+                user32.SwitchToThisWindow(hwnd, True)
+                user32.BringWindowToTop(hwnd)
+            except Exception:
+                pass
+
+        self._current_path = str(path)
+        self.presentation_opened.emit(self._current_path)
+        return True, ""
+
+    def next_slide(self) -> tuple[bool, str]:
+        view = self._slideshow_view()
+        if view is None:
+            return False, "Geen actieve slideshow"
+        try:
+            view.Next()
+            return True, ""
+        except Exception as e:
+            return False, f"Volgende slide mislukt: {e}"
+
+    def previous_slide(self) -> tuple[bool, str]:
+        view = self._slideshow_view()
+        if view is None:
+            return False, "Geen actieve slideshow"
+        try:
+            view.Previous()
+            return True, ""
+        except Exception as e:
+            return False, f"Vorige slide mislukt: {e}"
+
+    def goto_slide(self, slide_number: int) -> tuple[bool, str]:
+        view = self._slideshow_view()
+        if view is None:
+            return False, "Geen actieve slideshow"
+        if slide_number < 1:
+            return False, "Slide-nummer moet ≥ 1 zijn"
+        try:
+            view.GotoSlide(int(slide_number))
+            return True, ""
+        except Exception as e:
+            return False, f"Goto slide mislukt: {e}"
+
+    def close(self) -> tuple[bool, str]:
+        """Stop de slideshow en sluit de presentatie."""
+        self._close_presentation_if_any()
+        return True, ""
+
+    def is_slideshow_active(self) -> bool:
+        return self._slideshow_view() is not None
+
+    def shutdown(self) -> None:
+        self._close_presentation_if_any()
+        if self._app is not None and self._we_started_app:
+            try:
+                self._app.Quit()
+            except Exception:
+                pass
+        self._app = None
+        try:
+            pythoncom.CoUninitialize()
+        except Exception:
+            pass
+
+    # ---- intern ------------------------------------------------------------
+
+    def _slideshow_view(self):
+        if self._presentation is None:
+            return None
+        try:
+            window = self._presentation.SlideShowWindow
+        except Exception:
+            return None
+        if window is None:
+            return None
+        try:
+            view = window.View
+        except Exception:
+            return None
+        # Als de slideshow al gedaan is, geeft View.State 5 (Done) terug.
+        try:
+            if int(view.State) == _PP_SLIDE_SHOW_DONE:
+                return None
+        except Exception:
+            pass
+        return view
+
+    def _close_presentation_if_any(self) -> None:
+        if self._presentation is None:
+            return
+        # End slideshow als die nog draait.
+        try:
+            window = self._presentation.SlideShowWindow
+            if window is not None:
+                window.View.Exit()
+        except Exception:
+            pass
+        try:
+            self._presentation.Close()
+        except Exception:
+            pass
+        self._presentation = None
+        self._current_path = ""
+        # Minimaliseer de PowerPoint Application zelf zodat de (nu lege)
+        # editor niet over een volgende video- of presentatie-cue blijft
+        # staan. We laten 'm wel draaien — een volgende Open is dan snel.
+        if self._app is not None:
+            try:
+                self._app.WindowState = _PP_WINDOW_MINIMIZED
+            except Exception:
+                pass
+        self.presentation_closed.emit()
+
+
+# ---- status-registratie ----------------------------------------------------
+
+def register_status(engine: PowerPointEngine | None = None) -> None:
+    if not _COM_OK:
+        register(EngineStatus(
+            name="PowerPoint (COM)",
+            available=False,
+            detail=_COM_ERR or "pywin32 niet geladen",
+            short="ppt",
+        ))
+        return
+    register(EngineStatus(
+        name="PowerPoint (COM)",
+        available=True,
+        detail="pywin32 + COM beschikbaar (vereist Microsoft PowerPoint)",
+        short="ppt",
+    ))

--- a/livefire/playback/controller.py
+++ b/livefire/playback/controller.py
@@ -12,8 +12,8 @@ from dataclasses import dataclass, field
 
 from PyQt6.QtCore import QObject, QTimer, pyqtSignal
 
-from ..cues import Cue, CueType, ContinueMode
-from ..engines import AudioEngine, OscInputEngine, VideoEngine
+from ..cues import Cue, CueType, ContinueMode, PresentationAction
+from ..engines import AudioEngine, OscInputEngine, PowerPointEngine, VideoEngine
 from ..workspace import Workspace
 
 
@@ -45,6 +45,7 @@ class PlaybackController(QObject):
         audio: AudioEngine | None = None,
         osc: OscInputEngine | None = None,
         video: VideoEngine | None = None,
+        powerpoint: PowerPointEngine | None = None,
     ):
         super().__init__(parent)
         self.workspace = workspace
@@ -55,6 +56,7 @@ class PlaybackController(QObject):
         self.osc.message_received.connect(self._on_osc_message)
 
         self.video = video if video is not None else VideoEngine(self)
+        self.powerpoint = powerpoint if powerpoint is not None else PowerPointEngine(self)
 
         self._running: dict[str, _Running] = {}
         self._playhead_index: int = 0
@@ -77,6 +79,7 @@ class PlaybackController(QObject):
         self.audio.stop()
         self.osc.stop()
         self.video.shutdown()
+        self.powerpoint.shutdown()
 
     # ---- transport ---------------------------------------------------------
 
@@ -213,6 +216,20 @@ class PlaybackController(QObject):
             else:
                 r.action_duration = cue.duration if cue.duration > 0 else 0.0
 
+        elif t == CueType.PRESENTATION:
+            action = cue.presentation_action
+            if action == PresentationAction.OPEN:
+                self.powerpoint.open(cue.file_path)
+            elif action == PresentationAction.NEXT:
+                self.powerpoint.next_slide()
+            elif action == PresentationAction.PREVIOUS:
+                self.powerpoint.previous_slide()
+            elif action == PresentationAction.GOTO:
+                self.powerpoint.goto_slide(cue.presentation_slide)
+            elif action == PresentationAction.CLOSE:
+                self.powerpoint.close()
+            r.action_duration = 0.0
+
         elif t == CueType.WAIT:
             r.action_duration = cue.wait_duration
 
@@ -337,6 +354,18 @@ class PlaybackController(QObject):
                     elif r.stop_triggered:
                         if not self.video.is_playing(r.cue.id):
                             finished = True
+                elif (r.cue.cue_type == CueType.PRESENTATION
+                      and r.cue.presentation_action == PresentationAction.OPEN):
+                    # Wacht tot de slideshow klaar is (laatste slide gepasseerd
+                    # of user drukte ESC) voordat AUTO_FOLLOW de volgende
+                    # cue afvuurt. Sluit dan ook de presentatie zelf, anders
+                    # blijft de zwarte "klik om af te sluiten"-slide of de
+                    # PowerPoint-editor over onze UI staan.
+                    if not self.powerpoint.is_slideshow_active():
+                        finished = True
+                        self.powerpoint.close()
+                        if r.cue.continue_mode == ContinueMode.AUTO_FOLLOW:
+                            to_advance.append(cid)
                 else:
                     if elapsed_phase >= r.action_duration:
                         finished = True

--- a/livefire/ui/cuetoolbar.py
+++ b/livefire/ui/cuetoolbar.py
@@ -16,30 +16,33 @@ from ..cues import CueType
 # QLab gebruikt per cue-type een eigen kleur-accent. We doen hetzelfde zodat
 # de knoppen meteen herkenbaar zijn.
 _CUE_TYPE_ACCENTS = {
-    CueType.AUDIO:  "#2980b9",  # blauw
-    CueType.VIDEO:  "#16a085",  # teal
-    CueType.FADE:   "#c9a227",  # geel
-    CueType.WAIT:   "#606060",  # grijs
-    CueType.STOP:   "#c0392b",  # rood
-    CueType.START:  "#2e8b57",  # groen
-    CueType.GROUP:  "#7d3c98",  # paars
-    CueType.MEMO:   "#d35400",  # oranje
+    CueType.AUDIO:        "#2980b9",  # blauw
+    CueType.VIDEO:        "#16a085",  # teal
+    CueType.PRESENTATION: "#b03a2e",  # PowerPoint-rood
+    CueType.FADE:         "#c9a227",  # geel
+    CueType.WAIT:         "#606060",  # grijs
+    CueType.STOP:         "#c0392b",  # rood
+    CueType.START:        "#2e8b57",  # groen
+    CueType.GROUP:        "#7d3c98",  # paars
+    CueType.MEMO:         "#d35400",  # oranje
 }
 
 _CUE_TYPE_ORDER = [
-    CueType.AUDIO, CueType.VIDEO, CueType.FADE, CueType.WAIT, CueType.STOP,
+    CueType.AUDIO, CueType.VIDEO, CueType.PRESENTATION,
+    CueType.FADE, CueType.WAIT, CueType.STOP,
     CueType.START, CueType.GROUP, CueType.MEMO,
 ]
 
 _CUE_TYPE_TIPS = {
-    CueType.AUDIO: "Nieuwe Audio-cue (Ctrl+1)",
-    CueType.VIDEO: "Nieuwe Video-cue (Ctrl+8)",
-    CueType.FADE:  "Nieuwe Fade-cue (Ctrl+2)",
-    CueType.WAIT:  "Nieuwe Wait-cue (Ctrl+3)",
-    CueType.STOP:  "Nieuwe Stop-cue (Ctrl+4)",
-    CueType.GROUP: "Nieuwe Group-cue (Ctrl+5)",
-    CueType.MEMO:  "Nieuwe Memo-cue (Ctrl+6)",
-    CueType.START: "Nieuwe Start-cue (Ctrl+7)",
+    CueType.AUDIO:        "Nieuwe Audio-cue (Ctrl+1)",
+    CueType.VIDEO:        "Nieuwe Video-cue (Ctrl+8)",
+    CueType.PRESENTATION: "Nieuwe Presentatie-cue (Ctrl+9)",
+    CueType.FADE:         "Nieuwe Fade-cue (Ctrl+2)",
+    CueType.WAIT:         "Nieuwe Wait-cue (Ctrl+3)",
+    CueType.STOP:         "Nieuwe Stop-cue (Ctrl+4)",
+    CueType.GROUP:        "Nieuwe Group-cue (Ctrl+5)",
+    CueType.MEMO:         "Nieuwe Memo-cue (Ctrl+6)",
+    CueType.START:        "Nieuwe Start-cue (Ctrl+7)",
 }
 
 

--- a/livefire/ui/inspector.py
+++ b/livefire/ui/inspector.py
@@ -15,7 +15,7 @@ from PyQt6.QtWidgets import (
     QCheckBox, QHBoxLayout, QLabel,
 )
 
-from ..cues import Cue, CueType, ContinueMode
+from ..cues import Cue, CueType, ContinueMode, PresentationAction
 from ..engines.video import list_screens
 from ..workspace import Workspace
 from .style import CUE_COLORS
@@ -50,6 +50,9 @@ class InspectorWidget(QWidget):
         # Trim-punten zijn bestand-specifiek; bulk-edit zou van één bestand
         # naar ander bestand niet-zinvolle waardes toepassen.
         "video_start_offset", "video_end_offset",
+        # Presentatie-actie en slide-nummer zijn per cue logisch (bulk-edit
+        # naar bv. "Volgende slide" zou álle cues onderling vervangen).
+        "presentation_action", "presentation_slide",
     })
 
     def __init__(self, workspace: Workspace, parent=None):
@@ -232,6 +235,39 @@ class InspectorWidget(QWidget):
 
         lay.addWidget(self.grp_video)
 
+        # ---- Presentation --------------------------------------------------
+        self.grp_presentation = QGroupBox("Presentatie")
+        ppl = QFormLayout(self.grp_presentation)
+        self.cb_ppt_action = QComboBox()
+        for key in PresentationAction.ALL:
+            self.cb_ppt_action.addItem(PresentationAction.LABELS[key], key)
+        self.cb_ppt_action.setToolTip(
+            "Welke actie deze cue uitvoert op PowerPoint. 'Open' laadt het\n"
+            "bestand en start de slideshow; verdere cues sturen Volgende /\n"
+            "Vorige / Goto / Sluit naar de actieve presentatie."
+        )
+        ppl.addRow("Actie", self.cb_ppt_action)
+
+        ppt_path_row = QHBoxLayout()
+        self.ed_ppt_path = QLineEdit()
+        self.ed_ppt_path.setToolTip("Pad naar het .pptx-bestand (alleen voor 'Open').")
+        self.btn_browse_ppt = QPushButton("Bladeren…")
+        self.btn_browse_ppt.clicked.connect(self._browse_ppt)
+        ppt_path_row.addWidget(self.ed_ppt_path)
+        ppt_path_row.addWidget(self.btn_browse_ppt)
+        ppt_path_container = QWidget()
+        ppt_path_container.setLayout(ppt_path_row)
+        ppl.addRow("Bestand", ppt_path_container)
+        self._ppt_path_row = ppt_path_container  # voor show/hide
+
+        self.sp_ppt_slide = QSpinBox()
+        self.sp_ppt_slide.setRange(1, 9999)
+        self.sp_ppt_slide.setToolTip("Doel-slide (alleen voor 'Ga naar slide').")
+        ppl.addRow("Slide-nummer", self.sp_ppt_slide)
+        self._ppt_form = ppl
+
+        lay.addWidget(self.grp_presentation)
+
         # ---- Wait ----------------------------------------------------------
         self.grp_wait = QGroupBox("Wait")
         wl = QFormLayout(self.grp_wait)
@@ -326,10 +362,14 @@ class InspectorWidget(QWidget):
             # Hergebruik volume_db: audio en video delen hetzelfde veld zodat
             # je één range hebt om over na te denken (workspace blijft compat).
             self.sp_video_volume:   ("volume_db",           lambda: self.sp_video_volume.value()),
+            # Presentation
+            self.cb_ppt_action:     ("presentation_action", lambda: self.cb_ppt_action.currentData()),
+            self.ed_ppt_path:       ("file_path",           lambda: self.ed_ppt_path.text()),
+            self.sp_ppt_slide:      ("presentation_slide",  lambda: self.sp_ppt_slide.value()),
         }
 
         for w in (self.ed_number, self.ed_name, self.ed_path, self.ed_notes,
-                  self.ed_trigger_osc, self.ed_video_path):
+                  self.ed_trigger_osc, self.ed_video_path, self.ed_ppt_path):
             if isinstance(w, QPlainTextEdit):
                 w.textChanged.connect(self._on_any_change)
             else:
@@ -339,7 +379,7 @@ class InspectorWidget(QWidget):
                   self.sp_wait, self.sp_fade_target,
                   self.sp_video_fade_in, self.sp_video_fade_out,
                   self.sp_video_in, self.sp_video_out,
-                  self.sp_video_volume):
+                  self.sp_video_volume, self.sp_ppt_slide):
             w.valueChanged.connect(self._on_any_change)
         self.sp_loops.valueChanged.connect(self._on_any_change)
         self.cb_type.currentTextChanged.connect(self._on_type_change)
@@ -347,6 +387,8 @@ class InspectorWidget(QWidget):
         self.cb_target.currentIndexChanged.connect(self._on_any_change)
         self.cb_color.currentIndexChanged.connect(self._on_any_change)
         self.cb_video_screen.currentIndexChanged.connect(self._on_any_change)
+        self.cb_ppt_action.currentIndexChanged.connect(self._on_any_change)
+        self.cb_ppt_action.currentIndexChanged.connect(self._update_ppt_visibility)
         self.chk_fade_stops.toggled.connect(self._on_any_change)
 
         self.set_cues([])
@@ -399,6 +441,7 @@ class InspectorWidget(QWidget):
             self.header.setText("Geen cue geselecteerd")
             self.grp_audio.setVisible(False)
             self.grp_video.setVisible(False)
+            self.grp_presentation.setVisible(False)
             self.grp_wait.setVisible(False)
             self.grp_target.setVisible(False)
             self.content.setEnabled(False)
@@ -454,6 +497,13 @@ class InspectorWidget(QWidget):
         # zodat de spinbox-waarde binnen de zichtbare range valt.
         self.sp_video_volume.setValue(min(0.0, cue.volume_db))
 
+        # Presentation-velden
+        idx_action = self.cb_ppt_action.findData(cue.presentation_action)
+        if idx_action >= 0:
+            self.cb_ppt_action.setCurrentIndex(idx_action)
+        self.ed_ppt_path.setText(cue.file_path if not multi else "")
+        self.sp_ppt_slide.setValue(max(1, cue.presentation_slide))
+
         # Thumbnail-preview alleen laden voor single-select VIDEO-cues.
         if not multi and cue.cue_type == CueType.VIDEO and cue.file_path:
             self.video_preview.load(
@@ -472,7 +522,9 @@ class InspectorWidget(QWidget):
         # Per-cue velden uitschakelen bij multi-select.
         for w in (self.ed_number, self.ed_name, self.ed_path, self.ed_notes,
                   self.ed_trigger_osc, self.cb_target, self.btn_browse,
-                  self.btn_learn_osc, self.ed_video_path, self.btn_browse_video):
+                  self.btn_learn_osc, self.ed_video_path, self.btn_browse_video,
+                  self.ed_ppt_path, self.btn_browse_ppt, self.cb_ppt_action,
+                  self.sp_ppt_slide):
             w.setEnabled(not multi)
 
         self._updating = False
@@ -480,8 +532,20 @@ class InspectorWidget(QWidget):
     def _update_visibility(self, cue_type: str) -> None:
         self.grp_audio.setVisible(cue_type == CueType.AUDIO)
         self.grp_video.setVisible(cue_type == CueType.VIDEO)
+        self.grp_presentation.setVisible(cue_type == CueType.PRESENTATION)
         self.grp_wait.setVisible(cue_type == CueType.WAIT)
         self.grp_target.setVisible(cue_type in (CueType.STOP, CueType.FADE, CueType.START))
+        self._update_ppt_visibility()
+
+    def _update_ppt_visibility(self) -> None:
+        """Toon alleen de velden die relevant zijn voor de gekozen
+        Presentation-actie (Bestand bij Open, Slide-nummer bij Goto)."""
+        action = self.cb_ppt_action.currentData()
+        # QFormLayout.setRowVisible werkt op (label, field) paren via row-index.
+        self._ppt_form.setRowVisible(self._ppt_path_row,
+                                     action == PresentationAction.OPEN)
+        self._ppt_form.setRowVisible(self.sp_ppt_slide,
+                                     action == PresentationAction.GOTO)
 
     # ---- events ------------------------------------------------------------
 
@@ -572,6 +636,24 @@ class InspectorWidget(QWidget):
         visual_out = v if v > 0 else tl_out
         self.video_preview.set_markers(in_, v)
         self.video_preview.scrub_to(visual_out)
+
+    def _browse_ppt(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Kies presentatie", "",
+            "PowerPoint (*.pptx *.ppt *.pptm);;Alle bestanden (*)",
+        )
+        if not path:
+            return
+        old_path = self.ed_ppt_path.text().strip()
+        name = self.ed_name.text().strip()
+        auto_default = bool(re.match(
+            r"^(?:" + "|".join(CueType.ALL) + r") \d+$", name
+        ))
+        from_old_file = bool(old_path) and name == Path(old_path).stem
+        should_fill = not name or auto_default or from_old_file
+        self.ed_ppt_path.setText(path)
+        if should_fill and self.cue is not None and not len(self.cues) > 1:
+            self.ed_name.setText(Path(path).stem)
 
     def _browse_video(self) -> None:
         path, _ = QFileDialog.getOpenFileName(

--- a/livefire/ui/mainwindow.py
+++ b/livefire/ui/mainwindow.py
@@ -22,6 +22,7 @@ from ..engines.audio import (
     find_device_index_by_name,
 )
 from ..engines.osc import register_status as register_osc_status
+from ..engines.powerpoint import register_status as register_powerpoint_status
 from ..engines.video import register_status as register_video_status
 
 from .cuelist import CueListWidget
@@ -57,6 +58,7 @@ class MainWindow(QMainWindow):
         register_audio_status(self.controller.audio)
         register_osc_status(self.controller.osc)
         register_video_status(self.controller.video)
+        register_powerpoint_status(self.controller.powerpoint)
         # VLC-audio-device uit QSettings toepassen
         self._apply_video_audio_device_from_settings()
 
@@ -154,6 +156,8 @@ class MainWindow(QMainWindow):
                          tip="Speelt een audio-bestand af met volume, loops en fades")
         self._add_action(m_cue, "Nieuwe Video-cue", lambda: self.action_new_cue(CueType.VIDEO), QKeySequence("Ctrl+8"),
                          tip="Speelt een video-bestand fullscreen af op het gekozen scherm (libVLC)")
+        self._add_action(m_cue, "Nieuwe Presentatie-cue", lambda: self.action_new_cue(CueType.PRESENTATION), QKeySequence("Ctrl+9"),
+                         tip="Stuurt een PowerPoint-presentatie aan via COM (Open / Volgende slide / Vorige / Goto / Sluit)")
         self._add_action(m_cue, "Nieuwe Fade-cue", lambda: self.action_new_cue(CueType.FADE), QKeySequence("Ctrl+2"),
                          tip="Verandert het volume van een andere (lopende) audio-cue over tijd")
         self._add_action(m_cue, "Nieuwe Wait-cue", lambda: self.action_new_cue(CueType.WAIT), QKeySequence("Ctrl+3"),
@@ -393,8 +397,10 @@ class MainWindow(QMainWindow):
     _AUDIO_EXTS = {".wav", ".mp3", ".flac", ".ogg", ".aiff", ".aif", ".m4a"}
     _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm"}
     _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".tif"}
+    _PPT_EXTS = {".pptx", ".ppt", ".pptm"}
 
     def _on_files_dropped(self, paths: list[str]) -> None:
+        from ..cues import PresentationAction
         added = 0
         for p in paths:
             path = Path(p)
@@ -406,6 +412,10 @@ class MainWindow(QMainWindow):
             elif ext in self._VIDEO_EXTS:
                 cue = Cue(cue_type=CueType.VIDEO, cue_number=str(n),
                           name=path.stem, file_path=str(path))
+            elif ext in self._PPT_EXTS:
+                cue = Cue(cue_type=CueType.PRESENTATION, cue_number=str(n),
+                          name=path.stem, file_path=str(path),
+                          presentation_action=PresentationAction.OPEN)
             elif ext in self._IMAGE_EXTS:
                 cue = Cue(
                     cue_type=CueType.MEMO, cue_number=str(n), name=path.stem,

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,10 @@ python-osc>=1.8
 # Video
 python-vlc>=3.0
 
+# PowerPoint — COM-besturing voor Presentatie-cues. Vereist Windows +
+# Microsoft Office; engine degraded gracefully op machines zonder Office.
+pywin32>=305 ; sys_platform == "win32"
+
 # Optioneel nog uit te werken in komende versies:
 # pyartnet>=0.8      # DMX Art-Net (v0.5)
 # sacn>=1.9          # sACN E1.31 (v0.5)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -38,6 +38,12 @@ def test_roundtrip_preserves_all_cue_types(tmp_path: Path):
                    video_start_offset=2.0,
                    video_end_offset=8.5,
                    volume_db=-12.0))
+    ws.add_cue(Cue(cue_type=CueType.PRESENTATION, name="deck",
+                   file_path="C:/tmp/deck.pptx",
+                   presentation_action="open"))
+    ws.add_cue(Cue(cue_type=CueType.PRESENTATION, name="slide 3",
+                   presentation_action="goto",
+                   presentation_slide=3))
 
     p = tmp_path / "test.livefire"
     ws.save(p)
@@ -61,6 +67,8 @@ def test_roundtrip_preserves_all_cue_types(tmp_path: Path):
         assert orig.video_fade_out == got.video_fade_out
         assert orig.video_start_offset == got.video_start_offset
         assert orig.video_end_offset == got.video_end_offset
+        assert orig.presentation_action == got.presentation_action
+        assert orig.presentation_slide == got.presentation_slide
 
 
 def test_save_writes_current_format_version(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Nieuw cue-type **Presentation** dat PowerPoint aanstuurt via COM (\`pywin32\`). Acties: Open / Volgende slide / Vorige slide / Ga naar slide / Sluit. PowerPoint blijft de speler dus audio, video, animaties, transities en hyperlinks blijven werken — liveFire is alleen de cue-trigger.
- AUTO_FOLLOW op een Open-cue wacht tot de slideshow klaar is, sluit dan automatisch de presentatie en minimaliseert de PowerPoint-editor — geen "klik om af te sluiten"-zwarte slide en geen editor over de volgende cue.
- Drag-and-drop van \`.pptx/.ppt/.pptm\`, eigen menu-entry (Ctrl+9), eigen knop in de toolbar (PowerPoint-rood), inspector-groep met actie-dropdown + bestandsveld + slide-nummer.
- Vereist Microsoft PowerPoint + \`pywin32\` op de showmachine. Engine registreert zich in Engine-status, degradeert gracefully zonder Office.

## Test plan
- [ ] \`pytest tests/test_workspace.py\` — roundtrip groen (presentation_action + presentation_slide)
- [ ] Drag een .pptx in de cuelist → wordt automatisch een Open-cue
- [ ] Open-cue afvuren → PowerPoint slideshow komt fullscreen op de voorgrond, editor blijft onzichtbaar
- [ ] Open-cue met AUTO_FOLLOW → wacht tot slideshow klaar, sluit dan automatisch en de volgende cue start
- [ ] Volgende-slide / Vorige-slide cues werken op de actieve slideshow
- [ ] Een video-cue ná een gesloten slideshow toont het filmpje zonder PowerPoint-UI ertussen
- [ ] Engine-status (Help → Engine-status) toont "PowerPoint (COM)" als beschikbaar

🤖 Generated with [Claude Code](https://claude.com/claude-code)