### PR TITLE
feat: zwart-vrije video-overgangen + i18n NL/EN-toggle

### DIFF
--- a/livefire/__main__.py
+++ b/livefire/__main__.py
@@ -7,13 +7,12 @@ import time
 from pathlib import Path
 
 import ctypes
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QCoreApplication, QSettings
 from PyQt6.QtGui import QIcon
 from PyQt6.QtWidgets import QApplication, QSplashScreen
 
 from . import APP_NAME, SETTINGS_ORG, SETTINGS_APP
-from .ui import MainWindow, build_stylesheet
-from .ui.splash import build_splash_pixmap
+from .i18n import set_language
 
 
 _ICON_PATH = Path(__file__).parent / "resources" / "icon.png"
@@ -31,6 +30,16 @@ def main() -> int:
             )
         except Exception:
             pass
+
+    # Lees taal-setting voordat we UI-modules importeren — sommige module-
+    # level strings (bv. cuelist-kolomtitels) worden bij import al gezet.
+    QCoreApplication.setOrganizationName(SETTINGS_ORG)
+    QCoreApplication.setApplicationName(SETTINGS_APP)
+    set_language(QSettings().value("app/language", "nl", type=str))
+
+    # Imports hier zodat ze de juiste taal-strings oppakken.
+    from .ui import MainWindow, build_stylesheet
+    from .ui.splash import build_splash_pixmap
 
     app = QApplication(sys.argv)
     app.setOrganizationName(SETTINGS_ORG)

--- a/livefire/cues/base.py
+++ b/livefire/cues/base.py
@@ -55,11 +55,18 @@ class ContinueMode:
     AUTO_CONTINUE = 1   # volgende cue start zodra déze cue zijn actie start
     AUTO_FOLLOW = 2     # volgende cue start wanneer déze cue klaar is
 
-    LABELS = {
-        DO_NOT_CONTINUE: "Do Not Continue",
-        AUTO_CONTINUE: "Auto-Continue",
-        AUTO_FOLLOW: "Auto-Follow",
+    # i18n-keys; de display-labels worden via livefire.i18n.t() opgehaald
+    # zodat een taalwijziging in de UI doorkomt zonder workspace-migratie.
+    KEYS = {
+        DO_NOT_CONTINUE: "continue.do_not",
+        AUTO_CONTINUE:   "continue.auto_continue",
+        AUTO_FOLLOW:     "continue.auto_follow",
     }
+
+    @staticmethod
+    def label(mode: int) -> str:
+        from ..i18n import t
+        return t(ContinueMode.KEYS.get(mode, "continue.do_not"))
 
 
 @dataclass
@@ -97,6 +104,7 @@ class Cue:
     video_start_offset: float = 0.0  # in-punt in seconden (0 = vanaf begin)
     video_end_offset: float = 0.0    # uit-punt in seconden (0 = tot einde)
     video_file_duration: float = 0.0 # cache van file-duur; auto-gevuld door preview
+    video_last_frame_store: bool = False  # True = behoud laatste frame na einde, False = zwart
 
     # PowerPoint-presentatie
     presentation_action: str = PresentationAction.OPEN

--- a/livefire/engines/video.py
+++ b/livefire/engines/video.py
@@ -108,6 +108,15 @@ class VideoEngine(QObject):
                 global _VLC_ERR
                 _VLC_ERR = str(e)
         self._playing: dict[str, dict] = {}   # cue_id → {"player", "window", "fade_anim"}
+        # Preloaded entries: window + player al gemaakt, eerste frame
+        # gedecodeerd en gepauzeerd, venster nog onzichtbaar (opacity 0).
+        # Bij play_file pakken we de preload op zodat de switch naadloos is.
+        self._preloaded: dict[str, dict] = {}
+        # 'Lingering' vensters blijven na een cue-einde fullscreen staan
+        # (zwart of laatste frame, afhankelijk van last_frame_store) zodat
+        # we tussen manual GO's niet terug naar de UI flitsen. Worden
+        # opgeruimd zodra een nieuwe cue start of bij stop_all().
+        self._lingering: dict[str, dict] = {}
         self._audio_device: str = ""
 
     @property
@@ -128,46 +137,45 @@ class VideoEngine(QObject):
         start_offset: float = 0.0,
         end_offset: float = 0.0,
         volume_db: float = 0.0,
+        hold_last_frame: bool = False,
     ) -> tuple[bool, str]:
         if not self.available:
             return False, _VLC_ERR or "libVLC niet beschikbaar"
-        path = Path(file_path)
-        if not path.is_file():
-            return False, f"Bestand niet gevonden: {path}"
         # Bestaande player voor deze cue? Stop eerst.
         if cue_id in self._playing:
             self.stop_cue(cue_id, fade_out=0.0)
 
-        window = VideoWindow(screen_index=screen_index)
+        # Preloaded entry voor deze cue? Switch er direct naar — eerste
+        # frame is al gedecodeerd, dus geen zwart-flits.
+        if cue_id in self._preloaded:
+            entry = self._preloaded.pop(cue_id)
+            entry["hold_last_frame"] = hold_last_frame
+            self._activate_preloaded(cue_id, entry, fade_in)
+            return True, ""
+
+        path = Path(file_path)
+        if not path.is_file():
+            return False, f"Bestand niet gevonden: {path}"
+
+        entry = self._build_entry(
+            cue_id, path, screen_index, fade_out,
+            start_offset, end_offset, volume_db,
+        )
+        if entry is None:
+            return False, "Kon player niet aanmaken"
+        entry["hold_last_frame"] = hold_last_frame
+
+        window = entry["window"]
         window.showFullScreen()
         QGuiApplication.processEvents()
+        # Ruim lingering windows van vorige cues op pas NA showFullScreen,
+        # zodat de nieuwe window er bovenop ligt en we geen UI-flits krijgen.
+        self._clear_all_lingering()
+        entry["player"].play()
 
-        player = self._instance.media_player_new()  # type: ignore[union-attr]
-        player.set_hwnd(window.hwnd_id())
-        if self._audio_device:
-            try:
-                player.audio_output_device_set(None, self._audio_device)
-            except Exception:
-                pass
-
-        # In/uit-punt via media-opties. libVLC snapt :start-time / :stop-time.
-        media = self._instance.media_new(str(path))  # type: ignore[union-attr]
-        if start_offset > 0:
-            media.add_option(f":start-time={start_offset:.3f}")
-        if end_offset > 0:
-            media.add_option(f":stop-time={end_offset:.3f}")
-        player.set_media(media)
-        # Volume zetten vóór play() heeft op sommige libVLC-builds geen effect;
-        # we doen het ná play() én via set_media. Conversie dB → 0..100% (lineaire
-        # amplitude), boven unity clampen we omdat libVLC 100 als max behandelt.
-        try:
-            linear = 10 ** (volume_db / 20.0)
-            player.audio_set_volume(max(0, min(100, int(round(linear * 100)))))
-        except Exception:
-            pass
-        player.play()
-
-        # Fade-in via Qt window-opacity animation.
+        # Fade-in via Qt window-opacity animation; alleen als de gebruiker
+        # 'm expliciet heeft gezet. Manual GO is direct (geen wachttijd);
+        # AUTO_FOLLOW gebruikt het preload-pad voor naadloze cuts.
         if fade_in > 0:
             anim = QPropertyAnimation(window, b"windowOpacity")
             anim.setDuration(int(fade_in * 1000))
@@ -175,26 +183,150 @@ class VideoEngine(QObject):
             anim.setEndValue(1.0)
             anim.setEasingCurve(QEasingCurve.Type.InOutQuad)
             anim.start()
+            entry["fade_anim"] = anim
         else:
             window.setWindowOpacity(1.0)
-            anim = None
 
-        self._playing[cue_id] = {
+        self._playing[cue_id] = entry
+        return True, ""
+
+    def preload(
+        self,
+        cue_id: str,
+        file_path: str,
+        screen_index: int = 0,
+        fade_out: float = 0.0,
+        start_offset: float = 0.0,
+        end_offset: float = 0.0,
+        volume_db: float = 0.0,
+    ) -> bool:
+        """Maak alvast een verborgen player + window met het eerste frame
+        gedecodeerd en gepauzeerd. Bij een latere play_file(cue_id) switchen
+        we direct naar dit venster — geen libVLC decode-flits zichtbaar.
+
+        Bedoeld voor AUTO_FOLLOW: tijdens de huidige cue laden we vast de
+        volgende. Geen-op als 'r al een preload of speel-entry voor deze cue
+        is, of als libVLC niet beschikbaar is."""
+        if not self.available:
+            return False
+        if cue_id in self._preloaded or cue_id in self._playing:
+            return False
+        path = Path(file_path)
+        if not path.is_file():
+            return False
+        entry = self._build_entry(
+            cue_id, path, screen_index, fade_out,
+            start_offset, end_offset, volume_db,
+        )
+        if entry is None:
+            return False
+
+        window = entry["window"]
+        # Toon fullscreen, maar volledig transparant zodat libVLC kan
+        # renderen op de window-handle zonder dat de gebruiker iets ziet.
+        window.setWindowOpacity(0.0)
+        window.showFullScreen()
+        QGuiApplication.processEvents()
+        entry["player"].play()
+        # Pauzeer kort hierna zodat het eerste frame klaarstaat zonder
+        # dat de video al doorloopt.
+        QTimer.singleShot(180, lambda p=entry["player"]: self._pause_if_alive(p))
+        self._preloaded[cue_id] = entry
+        return True
+
+    def _activate_preloaded(self, cue_id: str, entry: dict, fade_in: float) -> None:
+        """Maak een preloaded entry actief: hervat de playback en zet 'm
+        op opacity 1 (of fade-in als de gebruiker dat wil)."""
+        window = entry["window"]
+        player = entry["player"]
+        try:
+            player.set_pause(False)
+        except Exception:
+            pass
+        if fade_in > 0:
+            anim = QPropertyAnimation(window, b"windowOpacity")
+            anim.setDuration(int(fade_in * 1000))
+            anim.setStartValue(window.windowOpacity())
+            anim.setEndValue(1.0)
+            anim.setEasingCurve(QEasingCurve.Type.InOutQuad)
+            anim.start()
+            entry["fade_anim"] = anim
+        else:
+            window.setWindowOpacity(1.0)
+        # Ruim lingering windows van vorige cues op nu de nieuwe zichtbaar is.
+        self._clear_all_lingering()
+        self._playing[cue_id] = entry
+
+    def discard_preload(self, cue_id: str) -> None:
+        """Gooi een preload weg (bijv. user heeft de playhead verzet)."""
+        entry = self._preloaded.pop(cue_id, None)
+        if entry is None:
+            return
+        try:
+            entry["player"].stop()
+            entry["player"].release()
+        except Exception:
+            pass
+        try:
+            entry["window"].close()
+            entry["window"].deleteLater()
+        except Exception:
+            pass
+
+    def _build_entry(
+        self,
+        cue_id: str,
+        path: Path,
+        screen_index: int,
+        fade_out: float,
+        start_offset: float,
+        end_offset: float,
+        volume_db: float,
+    ) -> dict | None:
+        """Maak een (player, window, media, ...) entry maar toon 'm nog niet
+        en start nog geen playback. Wordt door zowel play_file als preload
+        gebruikt zodat de logica één plek heeft."""
+        try:
+            window = VideoWindow(screen_index=screen_index)
+            player = self._instance.media_player_new()  # type: ignore[union-attr]
+            player.set_hwnd(window.hwnd_id())
+            if self._audio_device:
+                try:
+                    player.audio_output_device_set(None, self._audio_device)
+                except Exception:
+                    pass
+            media = self._instance.media_new(str(path))  # type: ignore[union-attr]
+            if start_offset > 0:
+                media.add_option(f":start-time={start_offset:.3f}")
+            if end_offset > 0:
+                media.add_option(f":stop-time={end_offset:.3f}")
+            player.set_media(media)
+            try:
+                linear = 10 ** (volume_db / 20.0)
+                player.audio_set_volume(max(0, min(100, int(round(linear * 100)))))
+            except Exception:
+                pass
+            em = player.event_manager()
+            em.event_attach(
+                vlc.EventType.MediaPlayerEndReached,  # type: ignore[union-attr]
+                lambda _e, cid=cue_id: QTimer.singleShot(0, lambda: self._on_end_reached(cid)),
+            )
+        except Exception:
+            return None
+        return {
             "player": player,
             "window": window,
             "media": media,
-            "fade_anim": anim,
+            "fade_anim": None,
             "fade_out_s": fade_out,
             "stop_ms": int(end_offset * 1000) if end_offset > 0 else 0,
         }
 
-        # Detecteer natuurlijk einde via VLC event.
-        em = player.event_manager()
-        em.event_attach(
-            vlc.EventType.MediaPlayerEndReached,  # type: ignore[union-attr]
-            lambda _e, cid=cue_id: QTimer.singleShot(0, lambda: self._on_end_reached(cid)),
-        )
-        return True, ""
+    def _pause_if_alive(self, player) -> None:
+        try:
+            player.set_pause(True)
+        except Exception:
+            pass
 
     def stop_cue(self, cue_id: str, fade_out: float = 0.0) -> None:
         entry = self._playing.get(cue_id)
@@ -218,6 +350,9 @@ class VideoEngine(QObject):
     def stop_all(self) -> None:
         for cid in list(self._playing.keys()):
             self._hard_stop(cid)
+        for cid in list(self._preloaded.keys()):
+            self.discard_preload(cid)
+        self._clear_all_lingering()
 
     def is_playing(self, cue_id: str) -> bool:
         """True zolang VLC actief rendert. False zodra de player in
@@ -272,32 +407,42 @@ class VideoEngine(QObject):
         if entry is None:
             return
         player = entry.get("player")
-        window = entry.get("window")
-        # Pauzeer eerst zodat het laatste frame zichtbaar blijft; ruim daarna
-        # met een korte delay op. Bij AUTO_FOLLOW van video → video heeft de
-        # volgende videowindow zo de tijd om fullscreen op te komen vóór deze
-        # weggaat — anders zie je tussendoor heel even de desktop/UI flitsen.
-        if player is not None:
-            try:
-                player.set_pause(True)
-            except Exception:
-                pass
-
-        def _cleanup() -> None:
-            try:
-                if player is not None:
+        if entry.get("hold_last_frame"):
+            # Pauzeer; window houdt het laatste frame vast tot een nieuwe
+            # cue start of stop_all() volgt.
+            if player is not None:
+                try:
+                    player.set_pause(True)
+                except Exception:
+                    pass
+        else:
+            # Stop de player (window-achtergrond is zwart). Frame blijft
+            # daarmee zwart fullscreen tussen cues — geen UI-flits.
+            if player is not None:
+                try:
                     player.stop()
-                    player.release()
-            except Exception:
-                pass
-            try:
-                if window is not None:
-                    window.close()
-                    window.deleteLater()
-            except Exception:
-                pass
+                except Exception:
+                    pass
+        self._lingering[cue_id] = entry
 
-        QTimer.singleShot(300, _cleanup)
+    def _dispose_lingering(self, cue_id: str) -> None:
+        entry = self._lingering.pop(cue_id, None)
+        if entry is None:
+            return
+        try:
+            entry["player"].stop()
+            entry["player"].release()
+        except Exception:
+            pass
+        try:
+            entry["window"].close()
+            entry["window"].deleteLater()
+        except Exception:
+            pass
+
+    def _clear_all_lingering(self) -> None:
+        for cid in list(self._lingering.keys()):
+            self._dispose_lingering(cid)
 
     def _on_end_reached(self, cue_id: str) -> None:
         """Draait op UI-thread via QTimer.singleShot. Signaleer aan de

--- a/livefire/engines/video.py
+++ b/livefire/engines/video.py
@@ -166,17 +166,19 @@ class VideoEngine(QObject):
         entry["hold_last_frame"] = hold_last_frame
 
         window = entry["window"]
+        # Als er een lingering frame staat (zwart of last-frame van een
+        # vorige cue): laat die zichtbaar tot libVLC een eerste frame heeft.
+        # Anders zien we kort zwart van onze nieuwe (nog lege) window.
+        has_linger = bool(self._lingering)
+        if has_linger:
+            window.setWindowOpacity(0.0)
         window.showFullScreen()
         QGuiApplication.processEvents()
-        # Ruim lingering windows van vorige cues op pas NA showFullScreen,
-        # zodat de nieuwe window er bovenop ligt en we geen UI-flits krijgen.
-        self._clear_all_lingering()
         entry["player"].play()
 
-        # Fade-in via Qt window-opacity animation; alleen als de gebruiker
-        # 'm expliciet heeft gezet. Manual GO is direct (geen wachttijd);
-        # AUTO_FOLLOW gebruikt het preload-pad voor naadloze cuts.
         if fade_in > 0:
+            # Expliciete user-fade: oude lingering meteen weg, fade van 0→1.
+            self._clear_all_lingering()
             anim = QPropertyAnimation(window, b"windowOpacity")
             anim.setDuration(int(fade_in * 1000))
             anim.setStartValue(0.0)
@@ -184,8 +186,22 @@ class VideoEngine(QObject):
             anim.setEasingCurve(QEasingCurve.Type.InOutQuad)
             anim.start()
             entry["fade_anim"] = anim
+        elif has_linger:
+            # Geef libVLC ~220 ms om het eerste frame te decoderen achter
+            # onze (transparante) nieuwe window. Daarna onthullen we 'm en
+            # ruimen we pas een tikje later de lingering frame op — die
+            # extra overlap voorkomt dat er één paint-tick zwart te zien is
+            # tussen "nieuwe op 1" en "oude verdwijnt".
+            def _reveal(cid: str = cue_id) -> None:
+                if cid not in self._playing:
+                    return
+                self._playing[cid]["window"].setWindowOpacity(1.0)
+                QTimer.singleShot(60, self._clear_all_lingering)
+            QTimer.singleShot(220, _reveal)
         else:
+            # Eerste cue na stilstand: meteen zichtbaar, geen wachttijd.
             window.setWindowOpacity(1.0)
+            self._clear_all_lingering()
 
         self._playing[cue_id] = entry
         return True, ""

--- a/livefire/i18n.py
+++ b/livefire/i18n.py
@@ -1,0 +1,141 @@
+"""Lichte i18n-laag. Geen Qt-tr() / .ts-bestanden — voor één applicatie
+met twee talen is een dict-lookup pragmatischer en code-review-bestendig.
+
+Gebruik:
+    from .i18n import t
+    label = t("cuetype.video")        # → "Video"
+
+De huidige taal is een module-level global; bij start lees je 'm uit
+QSettings en zet je 'm met set_language(). Wijzigingen tijdens de
+sessie vereisen een app-herstart om consistent door alle bestaande
+widgets te flowen — daar voorkomen we Qt's signal-spam mee.
+"""
+
+from __future__ import annotations
+
+LANGUAGE: str = "nl"
+
+# Talen die in de UI keuzelijst verschijnen.
+SUPPORTED: list[tuple[str, str]] = [
+    ("nl", "Nederlands"),
+    ("en", "English"),
+]
+
+_STRINGS: dict[str, dict[str, str]] = {
+    "nl": {
+        # Cue-types (display-labels — de Python-constanten blijven hetzelfde
+        # voor JSON-stabiliteit van workspaces).
+        "cuetype.Audio":        "Audio",
+        "cuetype.Video":        "Video",
+        "cuetype.Presentation": "Presentatie",
+        "cuetype.Group":        "Groep",
+        "cuetype.Wait":         "Wacht",
+        "cuetype.Stop":         "Stop",
+        "cuetype.Fade":         "Fade",
+        "cuetype.Memo":         "Memo",
+        "cuetype.Start":        "Start",
+        # Continue-modes
+        "continue.do_not":         "Niet doorgaan",
+        "continue.auto_continue":  "Auto-doorgaan",
+        "continue.auto_follow":    "Auto-volgen",
+        # Cue-states
+        "state.idle":     "wacht",
+        "state.running":  "actief",
+        "state.finished": "klaar",
+        # Cuelist-kolomtitels
+        "col.nr":       "Nr",
+        "col.type":     "Type",
+        "col.name":     "Naam",
+        "col.duration": "Duur",
+        "col.continue": "Continue",
+        "col.state":    "Status",
+        # Inspector-groep titels
+        "group.general":      "Algemeen",
+        "group.timing":       "Timing",
+        "group.audio":        "Audio",
+        "group.video":        "Video",
+        "group.presentation": "Presentatie",
+        "group.wait":         "Wacht",
+        "group.target":       "Doel",
+        "group.triggers":     "Triggers",
+        "group.notes":        "Notities",
+        # Menu's
+        "menu.file":      "&Bestand",
+        "menu.cue":       "&Cue",
+        "menu.transport": "&Transport",
+        "menu.help":      "&Help",
+        # Algemene knoppen
+        "btn.close":  "Sluiten",
+        "btn.cancel": "Annuleren",
+        "btn.ok":     "OK",
+        "btn.delete": "Verwijderen",
+        "btn.renumber": "Hernummeren",
+        # Voorkeuren — taal-veld
+        "prefs.language":         "Taal",
+        "prefs.language.tooltip":
+            "Taal van de interface. Wijziging treedt in werking na "
+            "herstart van liveFire.",
+        "prefs.language.restart_title": "Herstart vereist",
+        "prefs.language.restart_body":
+            "De taalwijziging wordt actief na een herstart van liveFire.",
+    },
+    "en": {
+        "cuetype.Audio":        "Audio",
+        "cuetype.Video":        "Video",
+        "cuetype.Presentation": "Presentation",
+        "cuetype.Group":        "Group",
+        "cuetype.Wait":         "Wait",
+        "cuetype.Stop":         "Stop",
+        "cuetype.Fade":         "Fade",
+        "cuetype.Memo":         "Memo",
+        "cuetype.Start":        "Start",
+        "continue.do_not":         "Do Not Continue",
+        "continue.auto_continue":  "Auto-Continue",
+        "continue.auto_follow":    "Auto-Follow",
+        "state.idle":     "idle",
+        "state.running":  "running",
+        "state.finished": "finished",
+        "col.nr":       "Nr",
+        "col.type":     "Type",
+        "col.name":     "Name",
+        "col.duration": "Duration",
+        "col.continue": "Continue",
+        "col.state":    "State",
+        "group.general":      "General",
+        "group.timing":       "Timing",
+        "group.audio":        "Audio",
+        "group.video":        "Video",
+        "group.presentation": "Presentation",
+        "group.wait":         "Wait",
+        "group.target":       "Target",
+        "group.triggers":     "Triggers",
+        "group.notes":        "Notes",
+        "menu.file":      "&File",
+        "menu.cue":       "&Cue",
+        "menu.transport": "&Transport",
+        "menu.help":      "&Help",
+        "btn.close":  "Close",
+        "btn.cancel": "Cancel",
+        "btn.ok":     "OK",
+        "btn.delete": "Delete",
+        "btn.renumber": "Renumber",
+        "prefs.language":         "Language",
+        "prefs.language.tooltip":
+            "Interface language. Change takes effect after restarting "
+            "liveFire.",
+        "prefs.language.restart_title": "Restart required",
+        "prefs.language.restart_body":
+            "The language change takes effect after restarting liveFire.",
+    },
+}
+
+
+def set_language(code: str) -> None:
+    global LANGUAGE
+    LANGUAGE = code if code in _STRINGS else "nl"
+
+
+def t(key: str) -> str:
+    """Lookup. Onbekende sleutel: retourneer 'm zelf zodat ontbrekende
+    vertalingen meteen zichtbaar zijn in de UI."""
+    return _STRINGS.get(LANGUAGE, _STRINGS["nl"]).get(key, key)

--- a/livefire/playback/controller.py
+++ b/livefire/playback/controller.py
@@ -210,6 +210,7 @@ class PlaybackController(QObject):
                 start_offset=cue.video_start_offset,
                 end_offset=cue.video_end_offset,
                 volume_db=cue.volume_db,
+                hold_last_frame=cue.video_last_frame_store,
             )
             if not ok:
                 r.action_duration = 0.0
@@ -272,6 +273,23 @@ class PlaybackController(QObject):
 
         else:
             r.action_duration = 0.0
+
+        # AUTO_FOLLOW + volgende cue is een Video → preload 'm vast zodat de
+        # transitie straks naadloos is (libVLC heeft het eerste frame al
+        # gedecodeerd voor we 'm tonen).
+        if cue.continue_mode == ContinueMode.AUTO_FOLLOW:
+            if self._playhead_index < len(self.workspace.cues):
+                nxt = self.workspace.cues[self._playhead_index]
+                if nxt.cue_type == CueType.VIDEO and nxt.file_path:
+                    self.video.preload(
+                        cue_id=nxt.id,
+                        file_path=nxt.file_path,
+                        screen_index=nxt.video_output_screen,
+                        fade_out=nxt.video_fade_out,
+                        start_offset=nxt.video_start_offset,
+                        end_offset=nxt.video_end_offset,
+                        volume_db=nxt.volume_db,
+                    )
 
         # Auto-continue: volgende cue start wanneer de actie start
         if cue.continue_mode == ContinueMode.AUTO_CONTINUE:

--- a/livefire/ui/cuelist.py
+++ b/livefire/ui/cuelist.py
@@ -11,11 +11,17 @@ from PyQt6.QtWidgets import (
 )
 
 from ..cues import Cue, CueType, ContinueMode
+from ..i18n import t
 from ..workspace import Workspace
 from .style import STATE_COLORS, ACCENT, TEXT_DIM, tint_for_row
 
 
-COLUMNS = ["Nr", "Type", "Naam", "Duur", "Continue", "Status"]
+def _columns() -> list[str]:
+    return [t("col.nr"), t("col.type"), t("col.name"),
+            t("col.duration"), t("col.continue"), t("col.state")]
+
+
+COLUMNS = _columns()
 
 
 class _CueRowDelegate(QStyledItemDelegate):
@@ -134,11 +140,11 @@ class CueListWidget(QTreeWidget):
             dur_value = cue.duration
         item = QTreeWidgetItem([
             cue.cue_number or str(index + 1),
-            cue.cue_type,
+            t(f"cuetype.{cue.cue_type}"),
             cue.name or "(naamloos)",
             _fmt_duration(dur_value),
-            ContinueMode.LABELS.get(cue.continue_mode, ""),
-            cue.state,
+            ContinueMode.label(cue.continue_mode),
+            t(f"state.{cue.state}"),
         ])
         item.setData(0, Qt.ItemDataRole.UserRole, cue.id)
         # Kleur status-cel
@@ -162,7 +168,7 @@ class CueListWidget(QTreeWidget):
                 cue = self.workspace.find(cue_id)
                 if cue is None:
                     return
-                item.setText(5, cue.state)
+                item.setText(5, t(f"state.{cue.state}"))
                 color = STATE_COLORS.get(cue.state, QColor("#888"))
                 item.setForeground(5, QBrush(color))
                 return
@@ -191,11 +197,11 @@ class CueListWidget(QTreeWidget):
             else:
                 dur_value = cue.duration
             item.setText(0, cue.cue_number or str(i + 1))
-            item.setText(1, cue.cue_type)
+            item.setText(1, t(f"cuetype.{cue.cue_type}"))
             item.setText(2, cue.name or "(naamloos)")
             item.setText(3, _fmt_duration(dur_value))
-            item.setText(4, ContinueMode.LABELS.get(cue.continue_mode, ""))
-            item.setText(5, cue.state)
+            item.setText(4, ContinueMode.label(cue.continue_mode))
+            item.setText(5, t(f"state.{cue.state}"))
             state_color = STATE_COLORS.get(cue.state, QColor("#888"))
             item.setForeground(5, QBrush(state_color))
             # Kleur-balk bijwerken

--- a/livefire/ui/dialogs/preferences.py
+++ b/livefire/ui/dialogs/preferences.py
@@ -17,6 +17,7 @@ from ...engines.audio import register_status as register_audio_status
 from ...engines.osc import OscInputEngine, DEFAULT_OSC_PORT
 from ...engines.osc import register_status as register_osc_status
 from ...engines.video import VideoEngine, list_audio_devices as list_vlc_audio_devices
+from ...i18n import LANGUAGE, SUPPORTED as I18N_SUPPORTED, t
 
 
 SUPPORTED_SAMPLE_RATES = [44100, 48000, 96000]
@@ -105,6 +106,16 @@ class PreferencesDialog(QDialog):
         video_form.addRow("Audio-device", self.cb_video_audio)
         root.addWidget(grp_video)
 
+        # ---- Interface (taal) ---------------------------------------------
+        grp_iface = QGroupBox("Interface")
+        iface_form = QFormLayout(grp_iface)
+        self.cb_language = QComboBox()
+        self.cb_language.setToolTip(t("prefs.language.tooltip"))
+        for code, label in I18N_SUPPORTED:
+            self.cb_language.addItem(label, code)
+        iface_form.addRow(t("prefs.language"), self.cb_language)
+        root.addWidget(grp_iface)
+
         # Waarden uit QSettings (of huidige engine-config als fallback).
         self._load_from_settings()
 
@@ -155,6 +166,10 @@ class PreferencesDialog(QDialog):
         video_dev = s.value("video/audio_device", "", type=str)
         v_idx = self.cb_video_audio.findData(video_dev)
         self.cb_video_audio.setCurrentIndex(v_idx if v_idx >= 0 else 0)
+
+        lang = s.value("app/language", LANGUAGE, type=str)
+        l_idx = self.cb_language.findData(lang)
+        self.cb_language.setCurrentIndex(l_idx if l_idx >= 0 else 0)
 
     # ---- apply -------------------------------------------------------------
 
@@ -217,5 +232,18 @@ class PreferencesDialog(QDialog):
         s.setValue("video/audio_device", video_dev)
         if self.video is not None:
             self.video.set_audio_device(video_dev)
+
+        # Taal opslaan; effect na herstart (sommige strings worden bij
+        # module-import al gezet, een live re-render is voor MVP te
+        # complex).
+        new_lang = self.cb_language.currentData() or "nl"
+        old_lang = s.value("app/language", LANGUAGE, type=str)
+        s.setValue("app/language", new_lang)
+        if new_lang != old_lang:
+            QMessageBox.information(
+                self,
+                t("prefs.language.restart_title"),
+                t("prefs.language.restart_body"),
+            )
 
         self.accept()

--- a/livefire/ui/inspector.py
+++ b/livefire/ui/inspector.py
@@ -16,6 +16,7 @@ from PyQt6.QtWidgets import (
 )
 
 from ..cues import Cue, CueType, ContinueMode, PresentationAction
+from ..i18n import t
 from ..engines.video import list_screens
 from ..workspace import Workspace
 from .style import CUE_COLORS
@@ -86,14 +87,17 @@ class InspectorWidget(QWidget):
         lay.addWidget(self.header)
 
         # ---- Basis-groep ---------------------------------------------------
-        grp_basic = QGroupBox("Algemeen")
+        grp_basic = QGroupBox(t("group.general"))
         form = QFormLayout(grp_basic)
         self.ed_number = QLineEdit()
         self.ed_number.setToolTip("Cue-nummer zoals getoond in de cuelist. Vrij tekstveld (mag letters bevatten).")
         self.ed_name = QLineEdit()
         self.ed_name.setToolTip("Korte beschrijving voor jezelf. Heeft geen invloed op playback.")
         self.cb_type = QComboBox()
-        self.cb_type.addItems(CueType.ALL)
+        # Toon vertaalde labels, maar bewaar de originele cue-type-string als
+        # data zodat workspaces compatibel blijven.
+        for ct in CueType.ALL:
+            self.cb_type.addItem(t(f"cuetype.{ct}"), ct)
         self.cb_type.setToolTip(
             "Type van de cue:\n"
             "• Audio — speelt een bestand\n"
@@ -116,7 +120,7 @@ class InspectorWidget(QWidget):
         lay.addWidget(grp_basic)
 
         # ---- Timing --------------------------------------------------------
-        grp_timing = QGroupBox("Timing")
+        grp_timing = QGroupBox(t("group.timing"))
         fl = QFormLayout(grp_timing)
         self.sp_pre = self._spin_seconds()
         self.sp_pre.setToolTip("Wachttijd tussen GO en het daadwerkelijk starten van deze cue.")
@@ -125,8 +129,8 @@ class InspectorWidget(QWidget):
         self.sp_post = self._spin_seconds()
         self.sp_post.setToolTip("Wachttijd nadat de actie klaar is, vóór de cue 'finished' wordt.")
         self.cb_continue = QComboBox()
-        for k, v in ContinueMode.LABELS.items():
-            self.cb_continue.addItem(v, k)
+        for k in ContinueMode.KEYS:
+            self.cb_continue.addItem(ContinueMode.label(k), k)
         self.cb_continue.setToolTip(
             "Hoe de playback doorgaat:\n"
             "• Do Not Continue — stopt na deze cue\n"
@@ -140,7 +144,7 @@ class InspectorWidget(QWidget):
         lay.addWidget(grp_timing)
 
         # ---- Audio ---------------------------------------------------------
-        self.grp_audio = QGroupBox("Audio")
+        self.grp_audio = QGroupBox(t("group.audio"))
         al = QFormLayout(self.grp_audio)
         path_row = QHBoxLayout()
         self.ed_path = QLineEdit()
@@ -180,7 +184,7 @@ class InspectorWidget(QWidget):
         lay.addWidget(self.grp_audio)
 
         # ---- Video ---------------------------------------------------------
-        self.grp_video = QGroupBox("Video")
+        self.grp_video = QGroupBox(t("group.video"))
         vl = QFormLayout(self.grp_video)
         video_path_row = QHBoxLayout()
         self.ed_video_path = QLineEdit()
@@ -214,6 +218,15 @@ class InspectorWidget(QWidget):
             "Afspeelvolume van de video-audio in dB. 0 dB = origineel, −6 dB = halve amplitude."
         )
         vl.addRow("Volume", self.sp_video_volume)
+        # Wat blijft er fullscreen staan na deze cue tot een volgende start?
+        # Standaard zwart; aangevinkt = laatste frame zichtbaar (paused).
+        self.chk_video_last_frame = QCheckBox("Bewaar laatste frame na einde")
+        self.chk_video_last_frame.setToolTip(
+            "Aan: na het einde van deze cue blijft het laatste frame fullscreen "
+            "staan tot een volgende cue start.\n"
+            "Uit (default): zwart fullscreen tussen cues — geen UI-flits."
+        )
+        vl.addRow("", self.chk_video_last_frame)
 
         # Thumbnail + timeline voor in/uit-punt scrubbing.
         self.video_preview = VideoPreviewWidget()
@@ -236,7 +249,7 @@ class InspectorWidget(QWidget):
         lay.addWidget(self.grp_video)
 
         # ---- Presentation --------------------------------------------------
-        self.grp_presentation = QGroupBox("Presentatie")
+        self.grp_presentation = QGroupBox(t("group.presentation"))
         ppl = QFormLayout(self.grp_presentation)
         self.cb_ppt_action = QComboBox()
         for key in PresentationAction.ALL:
@@ -269,7 +282,7 @@ class InspectorWidget(QWidget):
         lay.addWidget(self.grp_presentation)
 
         # ---- Wait ----------------------------------------------------------
-        self.grp_wait = QGroupBox("Wait")
+        self.grp_wait = QGroupBox(t("group.wait"))
         wl = QFormLayout(self.grp_wait)
         self.sp_wait = self._spin_seconds(max_val=3600.0)
         self.sp_wait.setToolTip("Hoe lang deze Wait-cue pauzeert voor de playback doorgaat.")
@@ -277,7 +290,7 @@ class InspectorWidget(QWidget):
         lay.addWidget(self.grp_wait)
 
         # ---- Target (Stop / Fade / Start) ---------------------------------
-        self.grp_target = QGroupBox("Doel")
+        self.grp_target = QGroupBox(t("group.target"))
         tl = QFormLayout(self.grp_target)
         self.cb_target = QComboBox()
         self.cb_target.setToolTip(
@@ -295,7 +308,7 @@ class InspectorWidget(QWidget):
         lay.addWidget(self.grp_target)
 
         # ---- Triggers ------------------------------------------------------
-        self.grp_triggers = QGroupBox("Triggers")
+        self.grp_triggers = QGroupBox(t("group.triggers"))
         trg = QFormLayout(self.grp_triggers)
         osc_row = QHBoxLayout()
         self.ed_trigger_osc = QLineEdit()
@@ -318,7 +331,7 @@ class InspectorWidget(QWidget):
         lay.addWidget(self.grp_triggers)
 
         # ---- Notities ------------------------------------------------------
-        grp_notes = QGroupBox("Notities")
+        grp_notes = QGroupBox(t("group.notes"))
         nl = QVBoxLayout(grp_notes)
         self.ed_notes = QPlainTextEdit()
         self.ed_notes.setMinimumHeight(60)
@@ -362,6 +375,7 @@ class InspectorWidget(QWidget):
             # Hergebruik volume_db: audio en video delen hetzelfde veld zodat
             # je één range hebt om over na te denken (workspace blijft compat).
             self.sp_video_volume:   ("volume_db",           lambda: self.sp_video_volume.value()),
+            self.chk_video_last_frame: ("video_last_frame_store", lambda: self.chk_video_last_frame.isChecked()),
             # Presentation
             self.cb_ppt_action:     ("presentation_action", lambda: self.cb_ppt_action.currentData()),
             self.ed_ppt_path:       ("file_path",           lambda: self.ed_ppt_path.text()),
@@ -382,7 +396,7 @@ class InspectorWidget(QWidget):
                   self.sp_video_volume, self.sp_ppt_slide):
             w.valueChanged.connect(self._on_any_change)
         self.sp_loops.valueChanged.connect(self._on_any_change)
-        self.cb_type.currentTextChanged.connect(self._on_type_change)
+        self.cb_type.currentIndexChanged.connect(self._on_type_change)
         self.cb_continue.currentIndexChanged.connect(self._on_any_change)
         self.cb_target.currentIndexChanged.connect(self._on_any_change)
         self.cb_color.currentIndexChanged.connect(self._on_any_change)
@@ -390,6 +404,7 @@ class InspectorWidget(QWidget):
         self.cb_ppt_action.currentIndexChanged.connect(self._on_any_change)
         self.cb_ppt_action.currentIndexChanged.connect(self._update_ppt_visibility)
         self.chk_fade_stops.toggled.connect(self._on_any_change)
+        self.chk_video_last_frame.toggled.connect(self._on_any_change)
 
         self.set_cues([])
 
@@ -461,7 +476,9 @@ class InspectorWidget(QWidget):
         # overschrijven alleen het gewijzigde veld, niet de rest.
         self.ed_number.setText(cue.cue_number if not multi else "")
         self.ed_name.setText(cue.name if not multi else "")
-        self.cb_type.setCurrentText(cue.cue_type)
+        idx_type = self.cb_type.findData(cue.cue_type)
+        if idx_type >= 0:
+            self.cb_type.setCurrentIndex(idx_type)
         self._select_color(cue.color)
 
         self.sp_pre.setValue(cue.pre_wait)
@@ -496,6 +513,7 @@ class InspectorWidget(QWidget):
         # Volume_db is gedeeld met audio; clamp visueel tot 0 dB voor video
         # zodat de spinbox-waarde binnen de zichtbare range valt.
         self.sp_video_volume.setValue(min(0.0, cue.volume_db))
+        self.chk_video_last_frame.setChecked(cue.video_last_frame_store)
 
         # Presentation-velden
         idx_action = self.cb_ppt_action.findData(cue.presentation_action)
@@ -549,7 +567,8 @@ class InspectorWidget(QWidget):
 
     # ---- events ------------------------------------------------------------
 
-    def _on_type_change(self, new_type: str) -> None:
+    def _on_type_change(self, _idx: int = 0) -> None:
+        new_type = self.cb_type.currentData() or CueType.AUDIO
         self._update_visibility(new_type)
         if self._updating or not self.cues:
             return


### PR DESCRIPTION
## Summary
Twee features op één branch (gecombineerd voor de release):

### Video-overgangen (geen UI-flits, geen zwart-flits)
- Default tussen video-cues blijft een fullscreen window staan met zwarte achtergrond ('lingering') zodat we tussen manual GO's nooit terug naar de UI flitsen.
- Per-cue checkbox **Bewaar laatste frame na einde** (\`video_last_frame_store\`): paused player, laatste frame zichtbaar in plaats van zwart.
- AUTO_FOLLOW: preload-mechanisme. Tijdens de huidige cue maken we al een verborgen window + player aan voor de volgende met het eerste frame gedecodeerd → naadloze cut.
- Manual GO na een lingering frame: nieuwe window blijft 220 ms transparant terwijl libVLC decodeert, daarna in één klap zichtbaar met 60 ms cleanup-overlap zodat er geen paint-tick zwart kan flitsen.
- \`_hard_stop\` is geen QTimer-cleanup-race meer (was vermoedelijk de bron van de eerdere crash bij de laatste fullscreen video).

### i18n / taalkeuze
- \`livefire/i18n.py\`: lichtgewicht \`t(key)\`-lookup met NL- + EN-dictionaries.
- \`ContinueMode.LABELS\` → \`ContinueMode.label()\` via \`t()\`.
- Cuelist-kolommen, cue-types, cue-states en continue-mode-labels worden vertaald getoond. Inspector cue-type-dropdown toont vertaalde labels — data blijft \`Audio\`/\`Video\`/etc. zodat workspaces compatibel blijven.
- Inspector groep-titels via \`t()\`.
- Voorkeuren krijgt een **Interface**-groep met taalkeuze. Wijziging vraagt app-restart.

## Test plan
- [ ] AUTO_FOLLOW video → video: naadloze cut, geen zwart, geen flits
- [ ] Manual GO video → video met default: zwart frame ertussen, geen UI zichtbaar
- [ ] Last-frame-store cue: laatste frame blijft zichtbaar tot volgende GO
- [ ] Korte video met Duration=2s: geen crash bij sluiten
- [ ] Voorkeuren → Interface → English → Herstart → cuelist-kolomtitels en cue-type-labels in EN

🤖 Generated with [Claude Code](https://claude.com/claude-code)