### PR TITLE
chore(release): liveFire 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,28 @@ Alle noemenswaardige wijzigingen aan dit project. Format volgens
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-04-25
+
+Grote feature-release. Bevat alles wat de oorspronkelijke roadmap voor
+v0.3.x t/m v0.6.0 in stapjes had ingedeeld plus extra features die uit
+de praktijk zijn voortgekomen.
+
 ### Toegevoegd
+- **Naadloze video-overgangen.** Tussen video-cues blijft een fullscreen
+  window staan met zwarte achtergrond ('lingering'), zodat we tussen
+  manual GO's nooit terug naar de UI flitsen. Per-cue checkbox
+  *Bewaar laatste frame na einde* houdt de video paused op het laatste
+  frame in plaats van zwart. AUTO_FOLLOW preload't de volgende video
+  tijdens de huidige cue (verborgen window + gedecodeerd eerste frame)
+  voor een naadloze cut. Manual GO na een lingering frame: nieuwe
+  window blijft 220 ms transparant achter de paused frame zodat libVLC
+  kan decoderen, daarna in één klap zichtbaar met 60 ms cleanup-overlap.
+- **Taalkeuze NL / EN.** Nieuwe `livefire/i18n.py` met `t(key)`-lookup
+  en NL+EN-dictionaries; cuelist-kolommen, cue-types, cue-states,
+  continue-modes en inspector groep-titels worden vertaald getoond.
+  Workspaces blijven compatibel — `Audio` / `Video` / etc. blijven de
+  interne values. Voorkeuren krijgt een Interface-groep met de
+  taal-keuze; wijziging vereist app-restart.
 - **Presentatie-cue** (PowerPoint via COM). Nieuw cue-type met acties
   Open / Volgende slide / Vorige slide / Ga naar slide / Sluit. Audio,
   video, animaties, transities en hyperlinks blijven werken want

--- a/livefire/__init__.py
+++ b/livefire/__init__.py
@@ -1,7 +1,7 @@
 """liveFire — cue-based playback applicatie voor Windows live events."""
 
 APP_NAME = "liveFire"
-APP_VERSION = "0.3.0"
+APP_VERSION = "0.4.0"
 WORKSPACE_FORMAT_VERSION = 2  # bump bij breaking changes in .livefire JSON
 WORKSPACE_EXT = ".livefire"
 


### PR DESCRIPTION
## Summary
Versie-bump naar 0.4.0 + CHANGELOG-sectie.

Bundelt alles sinds 0.3.0:
- Video-trim met live preview (#12)
- Fix UI-flits tussen video's (#13)
- Per-cue video-volume (#14)
- App-icoon + splash + Over-dialog (#15)
- PowerPoint-cues via COM (#16)
- Naadloze video-overgangen + i18n NL/EN-toggle (#17)

## Na merge
- \`git tag v0.4.0\` + push tags
- Optioneel: GitHub release-page maken

🤖 Generated with [Claude Code](https://claude.com/claude-code)