### PR TITLE
feat: single-instance lock + playhead-changed on go() / _advance_and_go

### DIFF
--- a/livefire/__main__.py
+++ b/livefire/__main__.py
@@ -7,9 +7,9 @@ import time
 from pathlib import Path
 
 import ctypes
-from PyQt6.QtCore import Qt, QCoreApplication, QSettings
+from PyQt6.QtCore import Qt, QCoreApplication, QSettings, QSharedMemory
 from PyQt6.QtGui import QFont, QIcon
-from PyQt6.QtWidgets import QApplication, QSplashScreen
+from PyQt6.QtWidgets import QApplication, QMessageBox, QSplashScreen
 
 from . import APP_NAME, SETTINGS_ORG, SETTINGS_APP
 from .i18n import set_language
@@ -17,6 +17,51 @@ from .i18n import set_language
 
 _ICON_PATH = Path(__file__).parent / "resources" / "icon.png"
 _SPLASH_DURATION_S = 3.5
+
+# Singleton-key voor de QSharedMemory-segment. Versionering ingebakken
+# zodat een toekomstige format-bump niet botst met een oude instance
+# die nog draait tijdens een upgrade.
+_SINGLETON_KEY = "livefire-singleton-v1"
+
+
+def _acquire_single_instance_lock(app: QApplication) -> QSharedMemory | None:
+    """Probeer een proces-brede lock te claimen. Returns de shared-memory
+    handle (die actief blijft zolang de app draait) of None als er al een
+    andere instance draait — in dat geval is er een nette dialog getoond
+    en moet de caller met exitcode != 0 afsluiten.
+
+    Werkt op Windows, macOS en Linux: QSharedMemory wraps Win32 named
+    objects respectievelijk POSIX shm. De kernel ruimt de segment auto-
+    matisch op wanneer het proces eindigt (ook bij crash), dus stale
+    locks zijn zeldzaam.
+    """
+    shm = QSharedMemory(_SINGLETON_KEY)
+    # attach() lukt alleen wanneer een andere instance de segment al
+    # heeft aangemaakt — dat is het signaal dat er al een liveFire
+    # draait.
+    if shm.attach():
+        shm.detach()
+        QMessageBox.warning(
+            None,
+            "liveFire is already running",
+            "Another instance of liveFire is already running on this machine.\n\n"
+            "Switch to that window instead — running two at once would clash on "
+            "the OSC-input port and audio device.",
+        )
+        return None
+    if not shm.create(1):
+        # Onverwachte fout (geen permissions, OS-resource-limit, ...).
+        QMessageBox.critical(
+            None,
+            "Cannot start liveFire",
+            "Failed to acquire single-instance lock:\n\n"
+            f"{shm.errorString()}",
+        )
+        return None
+    # Houd 'm aan de QApplication zodat hij niet door de garbage-
+    # collector wordt opgeruimd vóór app-exit.
+    app._singleton_shm = shm  # type: ignore[attr-defined]
+    return shm
 
 
 def main() -> int:
@@ -55,6 +100,13 @@ def main() -> int:
     if _ICON_PATH.is_file():
         app.setWindowIcon(QIcon(str(_ICON_PATH)))
     app.setStyleSheet(build_stylesheet())
+
+    # Single-instance gate. Twee instances tegelijk botsen op de OSC-
+    # input UDP-poort, het audio-device en het Companion-feedback-pad —
+    # dus verbieden we 't meteen met een nette dialog ipv te wachten
+    # tot één van de engines met een WinError 10048 omvalt.
+    if _acquire_single_instance_lock(app) is None:
+        return 1
 
     w = MainWindow()
     w.show()

--- a/livefire/playback/controller.py
+++ b/livefire/playback/controller.py
@@ -141,6 +141,12 @@ class PlaybackController(QObject):
             return
         cue = self.workspace.cues[self._playhead_index]
         self._playhead_index += 1
+        # UI moet weten dat de playhead bewogen is — anders blijft de
+        # oranje highlight op de oude rij staan wanneer go() via een
+        # extern pad (OSC, Stream Deck) wordt getriggerd. action_go in
+        # MainWindow bewerkt de cuelist al expliciet, dus voor het
+        # keyboard/menu-pad is dit een no-op (idempotent in cuelist).
+        self.playhead_changed.emit(self._playhead_index)
         self._start_cue(cue)
 
     def fire_cue(self, cue_id: str) -> bool:
@@ -497,6 +503,9 @@ class PlaybackController(QObject):
             return
         nxt = self.workspace.cues[self._playhead_index]
         self._playhead_index += 1
+        # Sync UI — zelfde reden als go(): zonder emit blijft de oranje
+        # highlight op de vorige rij staan tijdens AUTO_CONTINUE/AUTO_FOLLOW.
+        self.playhead_changed.emit(self._playhead_index)
         self._start_cue(nxt)
 
     # ---- group-cue afhandeling --------------------------------------------


### PR DESCRIPTION
Twee fixes:

1. **Single-instance gate** via QSharedMemory in `__main__.py`. Een tweede `python -m livefire` toont nu een nette "liveFire is already running"-dialog en exits met code 1, ipv door te starten en stilletjes te conflicten op de OSC-input poort, audio device en Companion-feedback-pad.

2. **`controller.go()` en `_advance_and_go()` emiten nu `playhead_changed`**. Daardoor blijft de oranje playhead-rij in sync wanneer GO via Stream Deck/OSC binnenkomt of wanneer AUTO_CONTINUE / AUTO_FOLLOW de chain doorduwt. Eerder bleef de highlight stuck op de oude cue. Loop-prevention via idempotente set_playhead aan beide kanten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)