### PR TITLE
feat(feedback): /livefire/elapsed for primary running cue

### DIFF
--- a/livefire/engines/osc_feedback.py
+++ b/livefire/engines/osc_feedback.py
@@ -20,6 +20,7 @@ Adres-schema (verzonden vanaf liveFire → Companion):
 * ``/livefire/remaining`` (float) — seconden, negatief bij count-up
 * ``/livefire/remaining/label`` (string) — naam van de cue die countdown drijft
 * ``/livefire/countdown_active`` (int) — 1=countdown, 0=count-up/idle
+* ``/livefire/elapsed`` (float) — elapsed seconds van de spelende cue
 * ``/livefire/cue/<cue_number>/state`` (string) — idle / running / finished
 * ``/livefire/cue/<cue_number>/name`` (string)
 * ``/livefire/cue/<cue_number>/type`` (string) — Audio / Video / etc.
@@ -221,6 +222,7 @@ class OscFeedbackEngine(QObject):
             "/livefire/countdown_active",
             1 if snap.get("countdown_active", False) else 0,
         )
+        self.send("/livefire/elapsed", float(snap.get("elapsed", 0.0)))
 
 
 def register_status(engine: OscFeedbackEngine | None = None) -> None:

--- a/livefire/playback/controller.py
+++ b/livefire/playback/controller.py
@@ -167,7 +167,25 @@ class PlaybackController(QObject):
 
         Pakt de audio-cue in 'action'-fase met de grootste resterende tijd.
         """
-        best: tuple[str, float, bool] | None = None
+        info = self._primary_running_info()
+        if info is None:
+            return None
+        return (info["label"], info["seconds"], info["is_countdown"])
+
+    def primary_elapsed(self) -> float | None:
+        """Elapsed-tijd in seconden van dezelfde cue die ``primary_countdown``
+        drijft. Bij een aftellende audio-cue groeit deze van 0 → duration;
+        bij een oneindige loop groeit 'ie ongebonden door."""
+        info = self._primary_running_info()
+        if info is None:
+            return None
+        return info["elapsed"]
+
+    def _primary_running_info(self) -> dict | None:
+        """Gedeelde helper voor primary_countdown en primary_elapsed.
+        Retourneert ``{label, seconds, is_countdown, elapsed}`` voor de
+        cue die de transport-display drijft, of None."""
+        best: dict | None = None
         best_remaining = -1.0
         for r in self._running.values():
             if r.phase != "action":
@@ -180,7 +198,10 @@ class PlaybackController(QObject):
                 remaining = max(0.0, r.action_duration - elapsed)
                 if remaining > best_remaining:
                     best_remaining = remaining
-                    best = (label, remaining, True)
+                    best = {
+                        "label": label, "seconds": remaining,
+                        "is_countdown": True, "elapsed": elapsed,
+                    }
             else:
                 src_remaining = self.audio.get_remaining(r.cue.id)
                 if src_remaining is None:
@@ -189,11 +210,17 @@ class PlaybackController(QObject):
                     # Oneindige loop — count-up
                     if elapsed > best_remaining:
                         best_remaining = elapsed
-                        best = (label, elapsed, False)
+                        best = {
+                            "label": label, "seconds": elapsed,
+                            "is_countdown": False, "elapsed": elapsed,
+                        }
                 else:
                     if src_remaining > best_remaining:
                         best_remaining = src_remaining
-                        best = (label, src_remaining, True)
+                        best = {
+                            "label": label, "seconds": src_remaining,
+                            "is_countdown": True, "elapsed": elapsed,
+                        }
         return best
 
     # ---- trigger-matching --------------------------------------------------

--- a/livefire/ui/mainwindow.py
+++ b/livefire/ui/mainwindow.py
@@ -549,6 +549,7 @@ class MainWindow(QMainWindow):
             phn = self.ws.cues[playhead].name or self.ws.cues[playhead].cue_number
         else:
             phn = ""
+        elapsed = self.controller.primary_elapsed() or 0.0
         return {
             "playhead": playhead,
             "playhead_total": total,
@@ -557,6 +558,7 @@ class MainWindow(QMainWindow):
             "remaining": remaining,
             "remaining_label": remaining_label,
             "countdown_active": countdown_active,
+            "elapsed": elapsed,
         }
 
     def _on_state_change_for_feedback(self, cue_id: str) -> None:


### PR DESCRIPTION
Voegt elapsed-tijd van de primary running cue toe aan de feedback-snapshot. Gedeelde `_primary_running_info()` helper voorkomt dupe-logica met `primary_countdown()`. Module-kant pakt dit op als 0.2.8 met split-tegels min/sec/tenths.