### PR TITLE
feat(feedback): per-cue color + snapshot-please for Companion

### DIFF
--- a/livefire/engines/osc_feedback.py
+++ b/livefire/engines/osc_feedback.py
@@ -182,13 +182,18 @@ class OscFeedbackEngine(QObject):
             return
         self.send(f"/livefire/cue/{cue_number}/state", state)
 
-    def send_cue_meta(self, cue_number: str, name: str, cue_type: str) -> None:
-        """Naam + type van een cue — door MainWindow geëmit na elke
-        workspace-mutatie zodat Companion's preset-labels meebewegen."""
+    def send_cue_meta(
+        self, cue_number: str, name: str, cue_type: str, color: str = "",
+    ) -> None:
+        """Naam + type + kleur van een cue — door MainWindow geëmit na
+        elke workspace-mutatie zodat Companion's preset-labels mee-
+        bewegen. Kleur is een hex-string als ``"#c0392b"`` of leeg
+        wanneer de cue geen kleurtag heeft."""
         if not cue_number:
             return
         self.send(f"/livefire/cue/{cue_number}/name", name or "")
         self.send(f"/livefire/cue/{cue_number}/type", cue_type or "")
+        self.send(f"/livefire/cue/{cue_number}/color", color or "")
 
     def send_cuecount(self, count: int) -> None:
         self.send("/livefire/cuecount", int(count))

--- a/livefire/playback/controller.py
+++ b/livefire/playback/controller.py
@@ -53,6 +53,10 @@ class PlaybackController(QObject):
     # te syncen. Niet geëmit door go() omdat MainWindow.action_go z'n
     # eigen sync-pad heeft (en we anders een loop met cuelist krijgen).
     playhead_changed = pyqtSignal(int)
+    # Companion-module vraagt om een verse cuelist-snapshot via
+    # /livefire/snapshot/please (zie _handle_livefire_command). MainWindow
+    # luistert hier en duwt _broadcast_cuelist_snapshot.
+    snapshot_requested = pyqtSignal()
     # Wanneer een Network-cue's OSC-send faalt (lege/ongeldige address,
     # python-osc niet beschikbaar, enz.), emit (cue_id, error_message).
     # De UI kan zich hieraan abonneren om de operator te waarschuwen.
@@ -263,6 +267,12 @@ class PlaybackController(QObject):
         if address == "/livefire/playhead/goto":
             if args and isinstance(args[0], (int, float)):
                 self.set_playhead(int(args[0]))
+            return
+        if address == "/livefire/snapshot/please":
+            # Companion vraagt na (re)connect een verse snapshot van de
+            # hele cuelist. We laten 't aan MainWindow over via 't signal
+            # zodat de controller niet hoeft te weten van OscFeedback.
+            self.snapshot_requested.emit()
             return
         # /livefire/fire/<cue_number> — match op cue.cue_number (vrij
         # tekstveld; we vergelijken case-sensitive).

--- a/livefire/ui/mainwindow.py
+++ b/livefire/ui/mainwindow.py
@@ -106,6 +106,11 @@ class MainWindow(QMainWindow):
         # tot volgende periodieke tick). Companion's feedback voelt dan
         # snappy.
         self.controller.cue_state_changed.connect(self._on_state_change_for_feedback)
+        # Companion vraagt na (re)connect een verse cuelist-snapshot via
+        # /livefire/snapshot/please. We pushen 't volledige plaatje opnieuw
+        # zodat namen, types en kleuren weer kloppen zonder dat de operator
+        # eerst een cue moet wijzigen.
+        self.controller.snapshot_requested.connect(self._broadcast_cuelist_snapshot)
         # NB. controller.playhead_changed → cue_list.set_playhead wordt
         # ná _build_ui() aangesloten, want de cue_list bestaat hier nog
         # niet.
@@ -579,7 +584,9 @@ class MainWindow(QMainWindow):
             return
         self.feedback.send_cuecount(len(self.ws.cues))
         for cue in self.ws.cues:
-            self.feedback.send_cue_meta(cue.cue_number, cue.name, cue.cue_type)
+            self.feedback.send_cue_meta(
+                cue.cue_number, cue.name, cue.cue_type, cue.color or "",
+            )
             self.feedback.send_cue_state(cue.cue_number, cue.state)
 
     # ---- reactive handlers ------------------------------------------------
@@ -636,7 +643,9 @@ class MainWindow(QMainWindow):
         # ongeacht welk veld is veranderd; het is goedkoop.
         cue = self.ws.find(_cue_id)
         if cue is not None and self.feedback.running:
-            self.feedback.send_cue_meta(cue.cue_number, cue.name, cue.cue_type)
+            self.feedback.send_cue_meta(
+                cue.cue_number, cue.name, cue.cue_type, cue.color or "",
+            )
             self.feedback.send_cue_state(cue.cue_number, cue.state)
         self._cue_field_refresh(_cue_id)
 


### PR DESCRIPTION
## Summary
- Add cue-color push to the Companion feedback channel — every cue meta-update now sends `/livefire/cue/<n>/color` with the inspector hex, so module fire-buttons can match the operator's color tag.
- Handle `/livefire/snapshot/please` from the module: controller emits a new `snapshot_requested` signal, MainWindow rebroadcasts the full cuelist (count + names + types + colors + states) — fixes the case where re-importing or reconnecting the module left fire-button labels empty until the operator manually edited a cue.

## Test plan
- [x] `pytest -q` (142 passed, 1 skipped)
- [ ] Verify Companion module receives `/livefire/cue/<n>/color` after each cue mutation
- [ ] Verify reconnecting the Companion instance triggers a fresh full snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)