### PR TITLE
feat(feedback): workspace + showtime + version meta push for Companion

### DIFF
--- a/livefire/engines/osc_feedback.py
+++ b/livefire/engines/osc_feedback.py
@@ -198,6 +198,13 @@ class OscFeedbackEngine(QObject):
     def send_cuecount(self, count: int) -> None:
         self.send("/livefire/cuecount", int(count))
 
+    def send_version(self, version: str) -> None:
+        """liveFire's APP_VERSION naar Companion. Bedoeld voor de version-
+        banner op de homescreen (`liveFire X.Y.Z • mod A.B.C`). Eenmalig
+        bij start van de feedback-engine — geen reden om dit elke tick
+        te pushen, de versie verandert niet tijdens runtime."""
+        self.send("/livefire/version", version or "")
+
     # ---- intern ------------------------------------------------------------
 
     def _on_tick(self) -> None:
@@ -228,6 +235,19 @@ class OscFeedbackEngine(QObject):
             1 if snap.get("countdown_active", False) else 0,
         )
         self.send("/livefire/elapsed", float(snap.get("elapsed", 0.0)))
+        # Workspace + showtime meta — gevoed door MainWindow.snapshot().
+        # Strings + int vlaggen, samen ~80 bytes per tick. Verwaarloosbaar
+        # op localhost UDP en de operator ziet meteen of er ongesaved werk
+        # ligt of dat de cuelist bevroren is.
+        self.send("/livefire/workspace_name", str(snap.get("workspace_name", "")))
+        self.send(
+            "/livefire/workspace_dirty",
+            1 if snap.get("workspace_dirty", False) else 0,
+        )
+        self.send(
+            "/livefire/showtime_locked",
+            1 if snap.get("showtime_locked", False) else 0,
+        )
 
 
 def register_status(engine: OscFeedbackEngine | None = None) -> None:

--- a/livefire/ui/mainwindow.py
+++ b/livefire/ui/mainwindow.py
@@ -621,6 +621,8 @@ class MainWindow(QMainWindow):
         # weet welke cues bestaan (anders pas zichtbaar bij de eerste
         # state-change op een cue).
         self._broadcast_cuelist_snapshot()
+        # liveFire-versie pushen voor de version-banner-tile in Companion.
+        self.feedback.send_version(APP_VERSION)
 
     # ---- snapshot-provider voor OscFeedbackEngine ------------------------
 
@@ -645,6 +647,12 @@ class MainWindow(QMainWindow):
         else:
             phn = ""
         elapsed = self.controller.primary_elapsed() or 0.0
+        # Workspace-meta voor de Companion-homescreen tiles. Naam is de
+        # bestandsnaam zonder extensie (compactere weergave op een knop);
+        # dirty=1 betekent unsaved edits. Showtime-lock geeft de operator
+        # de zekerheid dat de cuelist bevroren is.
+        ws_path = self.ws.path
+        ws_name = ws_path.stem if ws_path is not None else "Untitled"
         return {
             "playhead": playhead,
             "playhead_total": total,
@@ -654,6 +662,9 @@ class MainWindow(QMainWindow):
             "remaining_label": remaining_label,
             "countdown_active": countdown_active,
             "elapsed": elapsed,
+            "workspace_name": ws_name,
+            "workspace_dirty": bool(self.ws.dirty),
+            "showtime_locked": bool(self._showtime),
         }
 
     def _on_state_change_for_feedback(self, cue_id: str) -> None:


### PR DESCRIPTION
## Summary
Pushes three new pieces of liveFire meta over OSC so the Companion module 0.2.12 can render homescreen status tiles:
- \`/livefire/workspace_name\` — basename of the open workspace (or \"Untitled\")
- \`/livefire/workspace_dirty\` — 1/0
- \`/livefire/showtime_locked\` — 1/0
- \`/livefire/version\` — APP_VERSION, sent once on connect

The first three travel inside the existing 10 Hz periodic snapshot tick (cheap on localhost UDP). Version is sent once after the initial cuelist broadcast.

## Test plan
- [x] \`pytest -q\` (164 passed, 1 skipped)
- [ ] Module 0.2.12 receives all four addresses
- [ ] Workspace tile flips amber + 'UNSAVED' on edit, back on Save
- [ ] Showtime-lock indicator turns green when toggle is on

🤖 Generated with [Claude Code](https://claude.com/claude-code)