### PR TITLE
fix(feedback): push /livefire/version every tick + home glyph

### DIFF
--- a/livefire/engines/osc_feedback.py
+++ b/livefire/engines/osc_feedback.py
@@ -248,6 +248,7 @@ class OscFeedbackEngine(QObject):
             "/livefire/showtime_locked",
             1 if snap.get("showtime_locked", False) else 0,
         )
+        self.send("/livefire/version", str(snap.get("version", "")))
 
 
 def register_status(engine: OscFeedbackEngine | None = None) -> None:

--- a/livefire/ui/mainwindow.py
+++ b/livefire/ui/mainwindow.py
@@ -665,6 +665,7 @@ class MainWindow(QMainWindow):
             "workspace_name": ws_name,
             "workspace_dirty": bool(self.ws.dirty),
             "showtime_locked": bool(self._showtime),
+            "version": APP_VERSION,
         }
 
     def _on_state_change_for_feedback(self, cue_id: str) -> None:

--- a/tools/gen_glyphs.py
+++ b/tools/gen_glyphs.py
@@ -242,6 +242,40 @@ def clock(d: ImageDraw.ImageDraw) -> None:
     d.line([cx, cy, cx + 36, cy], fill=WHITE, width=6)
 
 
+def house(d: ImageDraw.ImageDraw) -> None:
+    # Home-glyph: dak (driehoek) + body (rechthoek) + deur (rechthoek-cutout
+    # die we als zwart-transparant tekenen). Klassieke home-icon-look.
+    cx = W // 2
+    # Dak — driehoek bovenaan
+    roof_top_y = 22
+    roof_base_y = 64
+    roof_half_w = 56
+    d.polygon(
+        [
+            (cx - roof_half_w, roof_base_y),
+            (cx + roof_half_w, roof_base_y),
+            (cx, roof_top_y),
+        ],
+        fill=WHITE,
+    )
+    # Body — rechthoek onder het dak (iets smaller dan dak-base zodat
+    # 't dak duidelijk overhangt)
+    body_left = cx - 44
+    body_right = cx + 44
+    body_top = 60
+    body_bottom = W - 22
+    d.rectangle(
+        [body_left, body_top, body_right, body_bottom], fill=WHITE,
+    )
+    # Deur — uitgespaard zodat 't huis 'n eigen silhouet houdt
+    door_w = 20
+    door_top = W // 2 + 6
+    d.rectangle(
+        [cx - door_w // 2, door_top, cx + door_w // 2, body_bottom],
+        fill=(0, 0, 0, 0),
+    )
+
+
 # ---- runner -------------------------------------------------------------
 
 
@@ -263,6 +297,7 @@ GLYPHS = [
     ("group", folder),
     ("standby", standby_circle),
     ("wait", clock),
+    ("home", house),
 ]
 
 


### PR DESCRIPTION
## Summary
- Add \`version\` to the periodic snapshot so \`/livefire/version\` rebroadcasts on every tick. Companion's \`livefire_version\` variable now refills within 100 ms of any module reconnect, instead of being empty until liveFire restarts.
- Add a \`home\` glyph to tools/gen_glyphs.py for the Stream Deck homescreen.

## Test plan
- [x] \`pytest -q\`
- [ ] Restart Companion mid-session — version variable repopulates within 1 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)