### PR TITLE
feat(osc): /livefire/showtime toggle + set for Companion

### DIFF
--- a/livefire/playback/controller.py
+++ b/livefire/playback/controller.py
@@ -57,6 +57,13 @@ class PlaybackController(QObject):
     # /livefire/snapshot/please (zie _handle_livefire_command). MainWindow
     # luistert hier en duwt _broadcast_cuelist_snapshot.
     snapshot_requested = pyqtSignal()
+    # Companion (of een andere OSC-source) wil de showtime-lock toggelen.
+    # MainWindow inverteert z'n eigen _showtime omdat die state daar leeft.
+    showtime_toggle_requested = pyqtSignal()
+    # Hetzelfde maar dan met een expliciete waarde (1 = aan, 0 = uit).
+    # Bedoeld voor scripted scenario's waar je expliciet wilt zetten i.p.v.
+    # toggelen — bv. "schakel showtime ALTIJD aan voor een bepaalde cue".
+    showtime_set_requested = pyqtSignal(bool)
     # Wanneer een Network-cue's OSC-send faalt (lege/ongeldige address,
     # python-osc niet beschikbaar, enz.), emit (cue_id, error_message).
     # De UI kan zich hieraan abonneren om de operator te waarschuwen.
@@ -279,6 +286,14 @@ class PlaybackController(QObject):
             # hele cuelist. We laten 't aan MainWindow over via 't signal
             # zodat de controller niet hoeft te weten van OscFeedback.
             self.snapshot_requested.emit()
+            return
+        if address == "/livefire/showtime/toggle":
+            # MainWindow inverteert z'n showtime-state.
+            self.showtime_toggle_requested.emit()
+            return
+        if address == "/livefire/showtime/set":
+            if args:
+                self.showtime_set_requested.emit(bool(args[0]))
             return
         # /livefire/fire/<cue_number> — match op cue.cue_number (vrij
         # tekstveld; we vergelijken case-sensitive).

--- a/livefire/ui/mainwindow.py
+++ b/livefire/ui/mainwindow.py
@@ -120,6 +120,15 @@ class MainWindow(QMainWindow):
         # zodat namen, types en kleuren weer kloppen zonder dat de operator
         # eerst een cue moet wijzigen.
         self.controller.snapshot_requested.connect(self._broadcast_cuelist_snapshot)
+        # OSC-driven showtime-lock — Companion module schakelt 'm aan/uit
+        # via deze signals. transport.set_showtime houdt de QPushButton-
+        # state in sync, en die emit op z'n beurt _on_showtime_toggled.
+        self.controller.showtime_toggle_requested.connect(
+            lambda: self.transport.set_showtime(not self._showtime)
+        )
+        self.controller.showtime_set_requested.connect(
+            self.transport.set_showtime
+        )
         # NB. controller.playhead_changed → cue_list.set_playhead wordt
         # ná _build_ui() aangesloten, want de cue_list bestaat hier nog
         # niet.


### PR DESCRIPTION
## Summary
Adds two OSC commands for the showtime-lock so the Companion module 0.2.17 can flip it from the Stream Deck:
- \`/livefire/showtime/toggle\` (no args) — invert current state
- \`/livefire/showtime/set <0|1>\` — force to a specific value

Both go through transport.set_showtime so the existing QPushButton chain remains the source of truth and the cuelist + inspector update via the same path as the manual toggle.

## Test plan
- [x] \`pytest -q\` (164 passed)
- [ ] Press the showtime-indicator preset on the Stream Deck → liveFire's transport-bar lock flips
- [ ] Toggle from liveFire's UI → Stream Deck button reflects new state via the existing showtime_locked feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)