### PR TITLE
feat(osc): /livefire/save for Companion save-on-press

### DIFF
--- a/livefire/playback/controller.py
+++ b/livefire/playback/controller.py
@@ -64,6 +64,10 @@ class PlaybackController(QObject):
     # Bedoeld voor scripted scenario's waar je expliciet wilt zetten i.p.v.
     # toggelen — bv. "schakel showtime ALTIJD aan voor een bepaalde cue".
     showtime_set_requested = pyqtSignal(bool)
+    # Companion's "save now"-knop (op de workspace_name-tile). MainWindow
+    # routeert naar action_save. Bestaat nog geen path? Dan opent action_save
+    # een Save-As-dialog — operator krijgt dan een prompt.
+    save_requested = pyqtSignal()
     # Wanneer een Network-cue's OSC-send faalt (lege/ongeldige address,
     # python-osc niet beschikbaar, enz.), emit (cue_id, error_message).
     # De UI kan zich hieraan abonneren om de operator te waarschuwen.
@@ -294,6 +298,9 @@ class PlaybackController(QObject):
         if address == "/livefire/showtime/set":
             if args:
                 self.showtime_set_requested.emit(bool(args[0]))
+            return
+        if address == "/livefire/save":
+            self.save_requested.emit()
             return
         # /livefire/fire/<cue_number> — match op cue.cue_number (vrij
         # tekstveld; we vergelijken case-sensitive).

--- a/livefire/ui/mainwindow.py
+++ b/livefire/ui/mainwindow.py
@@ -129,6 +129,8 @@ class MainWindow(QMainWindow):
         self.controller.showtime_set_requested.connect(
             self.transport.set_showtime
         )
+        # Companion vraagt save (workspace-name-tile = save-knop).
+        self.controller.save_requested.connect(self.action_save)
         # NB. controller.playhead_changed → cue_list.set_playhead wordt
         # ná _build_ui() aangesloten, want de cue_list bestaat hier nog
         # niet.


### PR DESCRIPTION
## Summary
Adds an OSC \`/livefire/save\` command so the Companion 0.2.18 workspace-name preset can save with one button-press. Routes through action_save so the no-path Save-As fallback still works.

## Test plan
- [x] \`pytest -q\` (164 passed)
- [ ] Stream Deck workspace-tile press → liveFire writes the file + dirty=0 push
- [ ] Module's recently_saved feedback flashes green SAVED for 1.5 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)